### PR TITLE
Portability overhaul: install docs, competitive landscape, platform invocation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "skill-portability-dev",
+  "name": "skill-portability-marketplace",
   "description": "Development marketplace for skill-portability",
   "owner": {
     "name": "Nathaniel Ramm",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Nathaniel Ramm",
     "email": "nathaniel.ramm@discretedatascience.com"
   },
-  "homepage": "https://github.com/nathanielramm/skill-portability",
-  "repository": "https://github.com/nathanielramm/skill-portability",
+  "homepage": "https://github.com/hiivmind/skill-portability",
+  "repository": "https://github.com/hiivmind/skill-portability",
   "license": "MIT",
   "keywords": ["skills", "portability", "multi-platform", "plugin-uplift"]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -7,8 +7,8 @@
     "name": "Nathaniel Ramm",
     "email": "nathaniel.ramm@discretedatascience.com"
   },
-  "homepage": "https://github.com/nathanielramm/skill-portability",
-  "repository": "https://github.com/nathanielramm/skill-portability",
+  "homepage": "https://github.com/hiivmind/skill-portability",
+  "repository": "https://github.com/hiivmind/skill-portability",
   "license": "MIT",
   "keywords": ["skills", "portability", "multi-platform", "plugin-uplift"],
   "skills": "./skills/"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ necessary across today's agent platforms.
 #### Marketplace install
 
 ```bash
-claude plugin install skill-portability@skill-portability-dev
+claude plugin install skill-portability@skill-portability-marketplace
 ```
 
 #### Local development
@@ -32,7 +32,14 @@ Add to `.claude/settings.json`:
 
 ```json
 {
-  "extraKnownMarketplaces": ["./path-to-marketplace"]
+  "extraKnownMarketplaces": {
+    "skill-portability-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "hiivmind/skill-portability"
+      }
+    }
+  }
 }
 ```
 
@@ -44,32 +51,57 @@ claude plugin list
 
 Look for `skill-portability` in the output.
 
+#### Using the skills
+
+In Claude Code, invoke skills by describing what you want in natural language:
+
+```
+Assess the portability of /path/to/my-plugin
+```
+
+```
+Use the uplifting-a-plugin skill on /path/to/my-plugin
+```
+
 ### Cursor
 
-#### Marketplace install
+#### Install from GitHub
 
-Search for **Skill Portability** in the Cursor marketplace panel or visit `cursor.com/marketplace`.
+In Cursor's Agent chat:
+
+```
+/add-plugin hiivmind/skill-portability
+```
 
 #### Local development
 
-Copy the plugin directory to `~/.cursor/plugins/local/skill-portability/` and restart Cursor (Developer: Reload Window).
+Symlink or copy the plugin directory to `~/.cursor/plugins/local/skill-portability/` and restart Cursor (Developer: Reload Window).
 
 #### Verify
 
 Open Cursor and check that skills from Skill Portability appear when typing `/` in chat.
+
+#### Using the skills
+
+In Cursor's chat, invoke skills with the `/` prefix:
+
+```
+/assessing-plugin-portability
+/uplifting-a-plugin
+```
 
 ### Gemini CLI
 
 #### Install from GitHub
 
 ```bash
-gemini extensions install https://github.com/nathanielramm/skill-portability
+gemini extensions install https://github.com/hiivmind/skill-portability
 ```
 
 #### Install from local path
 
 ```bash
-gemini extensions install /path/to/skill-portability
+gemini extensions link /path/to/skill-portability
 ```
 
 #### Verify
@@ -79,6 +111,16 @@ gemini extensions list
 ```
 
 Look for `skill-portability` in the output. Restart Gemini CLI if it was running during install.
+
+#### Using the skills
+
+Gemini CLI activates skills automatically when it determines they are relevant. You can also mention a skill by name:
+
+```
+Assess the portability of /path/to/my-plugin using assessing-plugin-portability
+```
+
+List available skills with `/skills list`.
 
 ### OpenCode
 
@@ -108,20 +150,28 @@ Restart OpenCode and check that skills are listed when the agent invokes the `sk
 
 OpenCode requires [Bun](https://bun.sh) for plugin loading.
 
+#### Using the skills
+
+OpenCode discovers skills automatically. Mention a skill by name and the agent will activate it:
+
+```
+Run assessing-plugin-portability on /path/to/my-plugin
+```
+
 ### Copilot CLI
 
 #### Skill install
 
-Skills are auto-discovered from the `skills/` directory. Clone the repo and skills will be available:
+Install skills via GitHub CLI:
 
 ```bash
-git clone https://github.com/nathanielramm/skill-portability
+gh skill install hiivmind/skill-portability
 ```
 
-Alternatively, install individual skills:
+Or clone the repo — skills are auto-discovered from the `skills/` directory:
 
 ```bash
-gh skill install https://github.com/nathanielramm/skill-portability
+git clone https://github.com/hiivmind/skill-portability
 ```
 
 #### Context
@@ -138,6 +188,15 @@ copilot
 
 Type `/` to see available skills.
 
+#### Using the skills
+
+In Copilot CLI, invoke skills with the `/` prefix:
+
+```
+/assessing-plugin-portability
+/uplifting-a-plugin
+```
+
 ### Codex
 
 #### Skill-discovery install
@@ -145,7 +204,7 @@ Type `/` to see available skills.
 Clone the repo and expose the skills directory:
 
 ```bash
-git clone https://github.com/nathanielramm/skill-portability
+git clone https://github.com/hiivmind/skill-portability
 ln -s $(pwd)/skill-portability/skills ~/.agents/skills/skill-portability
 ```
 
@@ -158,6 +217,15 @@ Codex uses `AGENTS.md` as its primary context file.
 #### Verify
 
 Start a new Codex session and check that skills are listed.
+
+#### Using the skills
+
+In Codex, invoke skills with the `$` prefix:
+
+```
+$assessing-plugin-portability
+$uplifting-a-plugin
+```
 
 ## Adding Another Platform
 
@@ -175,7 +243,14 @@ Or add to `.claude/settings.json` for persistent access:
 
 ```json
 {
-  "extraKnownMarketplaces": ["/path/to/existing/skill-portability"]
+  "extraKnownMarketplaces": {
+    "skill-portability-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "hiivmind/skill-portability"
+      }
+    }
+  }
 }
 ```
 
@@ -191,10 +266,10 @@ Restart Cursor (Developer: Reload Window).
 
 ### Gemini CLI
 
-Point Gemini at your existing checkout:
+Link Gemini to your existing checkout:
 
 ```bash
-gemini extensions install /path/to/existing/skill-portability
+gemini extensions link /path/to/existing/skill-portability
 ```
 
 ### OpenCode

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ Point it at a plugin repo and it tells you what's missing. Say the word and it e
 
 ## How it's different
 
-The cross-platform skill portability space is full of [CLI tools and broad frameworks](docs/competitive-landscape.md). They require installation, maintain canonical directories or registries, and often absorb scope far beyond portability (workflows, memory systems, eval loops, marketplaces).
+The cross-platform skill portability space is full of [CLI tools, sync daemons, and broad frameworks](docs/competitive-landscape.md). They are separate programs you install and run alongside your agent. Most target consumers (people installing others' skills), not authors. The few that do target authors only convert from Claude Code, and do so blindly — no gap analysis, no publishing guidance.
 
 skill-portability takes a different approach:
 
-- **It's a skill, not a CLI.** Runs inside the agent. Nothing to install beyond the plugin itself.
+- **It works where authors already work.** It's a plugin you install into the same agent you're already using to build your skill. No context switch, no separate CLI — assessment and uplift happen inside the authoring workflow.
 - **Analysis first.** Examines what platform artifacts exist and reports gaps before touching anything.
+- **Any platform as input.** Not locked to Claude Code as the starting point. A Cursor plugin, a Codex skill, a bare SKILL.md — all valid inputs.
 - **Optional uplift in place.** Emits missing artifacts directly into the project in each platform's native format. No intermediate representation, no `.agents/` directory to maintain.
-- **Zero infrastructure.** No marketplace, no registry, no sync daemon. One job: assess and optionally fill portability gaps.
+- **Publishing guidance included.** Generates PUBLISHING.md with per-platform steps for getting discovered and installed — not just the artifacts, but how to ship them.
 
-## What it emits
+## What it does
 
 Starting from whatever platform manifests already exist, it detects plugin metadata and generates everything missing:
 
@@ -48,12 +49,45 @@ This plugin owes a direct debt to [obra/superpowers](https://github.com/obra/sup
 
 ## Installation
 
-See [INSTALL.md](INSTALL.md) for per-platform install instructions covering Claude Code, Cursor, Gemini CLI, OpenCode, Codex, and Copilot CLI.
+Full details for all platforms in [INSTALL.md](INSTALL.md).
 
-**Quick start (Claude Code):**
+**Claude Code** — register the marketplace, then install:
+
+```
+/plugin marketplace add hiivmind/skill-portability
+/plugin install skill-portability@skill-portability-marketplace
+```
+
+**Cursor** — in Agent chat:
+
+```
+/add-plugin hiivmind/skill-portability
+```
+
+**Gemini CLI:**
 
 ```bash
-claude plugin install skill-portability@skill-portability-marketplace
+gemini extensions install https://github.com/hiivmind/skill-portability
+```
+
+**Copilot CLI:**
+
+```bash
+gh skill install hiivmind/skill-portability
+```
+
+**Codex:**
+
+```bash
+git clone https://github.com/hiivmind/skill-portability
+ln -s $(pwd)/skill-portability/skills ~/.agents/skills/skill-portability
+```
+
+**OpenCode** — clone and copy the plugin entrypoint:
+
+```bash
+git clone https://github.com/hiivmind/skill-portability
+cp skill-portability/.opencode/plugins/skill-portability.js .opencode/plugins/
 ```
 
 ## Usage
@@ -66,5 +100,3 @@ claude plugin install skill-portability@skill-portability-marketplace
 | **Codex** | `$assessing-plugin-portability` | `$uplifting-a-plugin` |
 | **Gemini CLI** | Mention skill by name — auto-activated | Same |
 | **OpenCode** | Mention skill by name — auto-activated | Same |
-
-See [INSTALL.md](INSTALL.md) for full install and usage details per platform.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Skill Portability
 
-An agent skill — not a CLI, not a framework — that makes any plugin fully portable across all agent platforms.
+A plugin for agent skill and plugin authors who have built for one platform — often Claude Code — and need to go cross-platform.
 
-Point it at a plugin repo and it tells you what's missing. Say the word and it emits every missing artifact in place. No install step, no sync daemon, no registry. The agent itself is the portability engine.
+Point it at a plugin repo and it tells you what's missing. Say the word and it emits every missing artifact in place — platform manifests, context files, tool mappings, install docs, and publishing guidance. No CLI to install, no sync daemon, no registry. The agent itself is the portability engine.
 
 ## How it's different
 

--- a/README.md
+++ b/README.md
@@ -53,19 +53,18 @@ See [INSTALL.md](INSTALL.md) for per-platform install instructions covering Clau
 **Quick start (Claude Code):**
 
 ```bash
-claude plugin install skill-portability@skill-portability-dev
+claude plugin install skill-portability@skill-portability-marketplace
 ```
 
 ## Usage
 
-Audit a plugin's portability gaps:
+| Platform | Assess portability | Uplift a plugin |
+|----------|--------------------|-----------------|
+| **Claude Code** | `Assess the portability of /path/to/plugin` | `Use the uplifting-a-plugin skill on /path/to/plugin` |
+| **Cursor** | `/assessing-plugin-portability` | `/uplifting-a-plugin` |
+| **Copilot CLI** | `/assessing-plugin-portability` | `/uplifting-a-plugin` |
+| **Codex** | `$assessing-plugin-portability` | `$uplifting-a-plugin` |
+| **Gemini CLI** | Mention skill by name — auto-activated | Same |
+| **OpenCode** | Mention skill by name — auto-activated | Same |
 
-```
-Use the assessing-plugin-portability skill on /path/to/your/plugin
-```
-
-Then uplift it:
-
-```
-Use the uplifting-a-plugin skill on /path/to/your/plugin
-```
+See [INSTALL.md](INSTALL.md) for full install and usage details per platform.

--- a/docs/competitive-landscape.md
+++ b/docs/competitive-landscape.md
@@ -5,17 +5,29 @@
 
 ## Overview
 
-A growing ecosystem of projects aims to solve the same core problem as skill-portability: skills and plugins written for one AI coding agent (typically Claude Code) should work across all major agents without rewriting. This document catalogues the known projects, their approaches, and emerging patterns.
+A growing ecosystem of projects aims to solve cross-platform skill and plugin portability for AI coding agents. This document catalogues the known projects, their approaches, and where skill-portability fits.
+
+### The Two Audiences
+
+Every portability project serves one or both of two distinct audiences:
+
+| Audience | What they need | Example workflow |
+|----------|---------------|------------------|
+| **Consumer** | Install and use skills written by others across their preferred agents | "I found a great Claude Code skill — make it work in Cursor" |
+| **Author** | Publish a skill/plugin they wrote for one platform to all other platforms | "I built a plugin for Claude Code — what do I need to add for Codex, Cursor, Gemini?" |
+
+Most projects in this space target **consumers**. Very few help **authors** — and the ones that do are either one-directional (Claude-only input) or very early stage.
 
 ---
 
-## Direct Competitors
+## Consumer-Focused Tools
 
-These projects share the same primary goal: write skills once, deploy everywhere.
+These projects help users install, sync, and discover skills across platforms. They do not help authors analyse what their plugin is missing or emit platform-specific artifacts.
 
 ### 1. SkillKit
 
 - **Repo:** [rohitg00/skillkit](https://github.com/rohitg00/skillkit)
+- **Audience:** Consumer (primarily)
 - **Tagline:** "Supercharge AI coding agents with portable skills"
 - **Scope:** Package manager for AI agent skills. Claims 45 agent targets and 400K+ skills across registries.
 - **Key features:**
@@ -27,10 +39,12 @@ These projects share the same primary goal: write skills once, deploy everywhere
   - AI-powered translation with trust scores across any LLM (Claude, GPT-4, Gemini, Ollama, OpenRouter)
 - **Agents supported:** Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Copilot, Windsurf, Devin, Aider, Sourcegraph Cody, Amazon Q, and 34 more
 - **Differentiator:** Marketplace/registry approach with the largest claimed agent coverage. Positions as npm-for-skills.
+- **Author relevance:** The `translate` command could serve authors, but it is positioned as a consumer convenience — no gap analysis, no assessment of what's missing, no publishing guidance.
 
 ### 2. Agentloom
 
 - **Site:** [agentloom.sh](https://agentloom.sh/docs)
+- **Audience:** Consumer
 - **Tagline:** "One agent config. Every AI tool."
 - **Scope:** Unified `.agents/` directory with `agentloom sync` to write native configs for all providers.
 - **Key features:**
@@ -44,6 +58,7 @@ These projects share the same primary goal: write skills once, deploy everywhere
 ### 3. polyagent-skills
 
 - **Repo:** [gyanranjan/polyagent-skills](https://github.com/gyanranjan/polyagent-skills)
+- **Audience:** Consumer (with author-adjacent patterns)
 - **Tagline:** "Write AI agent skills once, use everywhere"
 - **Scope:** Spec-driven, agent-agnostic skill library with thin adapter files per agent.
 - **Key features:**
@@ -53,10 +68,12 @@ These projects share the same primary goal: write skills once, deploy everywhere
   - Install script handles global setup
 - **Agents supported:** Claude Code, Codex, Kiro, Gemini CLI, Gemini Code Assist, OpenClaw, Cursor, Windsurf (planned)
 - **Differentiator:** Explicit adapter directory structure. Lighter-weight than SkillKit — no CLI tool, just a repo structure convention with adapters.
+- **Author relevance:** The adapter pattern helps authors structure a multi-platform repo, but it is a convention to follow manually — no tooling to analyse what is missing.
 
 ### 4. AllAgents
 
 - **Site:** [allagents.dev](https://allagents.dev/)
+- **Audience:** Consumer
 - **Tagline:** "All your AI assistants. One plugin system."
 - **Scope:** Plugin registries with skills/, hooks/, agents/ that sync declaratively via YAML.
 - **Key features:**
@@ -70,6 +87,7 @@ These projects share the same primary goal: write skills once, deploy everywhere
 ### 5. @agents-dev/cli
 
 - **Repo:** [amtiyo/agents](https://github.com/amtiyo/agents)
+- **Audience:** Consumer
 - **Tagline:** "One .agents source of truth"
 - **Scope:** CLI that syncs MCP servers, skills, and instructions from `.agents/` to all targets.
 - **Key features:**
@@ -83,14 +101,42 @@ These projects share the same primary goal: write skills once, deploy everywhere
 
 ---
 
+## Author-Focused Tools
+
+These projects specifically help plugin and skill authors make their work available across platforms.
+
+### 6. acplugin
+
+- **Repo:** [TokenRollAI/acplugin](https://github.com/tokenRollAI/acplugin)
+- **Audience:** Author (Claude Code only as input)
+- **Scope:** Converts Claude Code plugins to Codex CLI, OpenCode, Cursor, and Google Antigravity formats.
+- **Key features:**
+  - Scans a Claude Code plugin (local or GitHub) and rewrites skills, instructions (CLAUDE.md to AGENTS.md/.cursor/rules), MCP configs, agents, commands, and hooks into each target platform's format
+  - Handles model mapping (Claude models to GPT-5.4/Gemini 3 Pro)
+  - Interactive TUI for selecting plugins and platforms
+  - Supports marketplace repos
+- **Maturity:** 19 stars, 1 contributor, TypeScript, created 2026-03-22. Very early stage.
+- **Limitation:** One-directional — only converts FROM Claude Code. Cannot accept a Cursor, Codex, or Gemini plugin as input. No gap analysis or assessment step — converts everything blindly.
+
+### 7. claude-to-codex
+
+- **Repo:** [padmilkhandelwal/convert-claude-to-codex-skill](https://github.com/padmilkhandelwal/convert-claude-to-codex-skill)
+- **Audience:** Author (Claude Code → Codex only)
+- **Scope:** Single-direction converter that searches the Claude skill marketplace, fetches a skill, transforms tool references and frontmatter, generates `agents/openai.yaml`, validates output, and installs as a Codex skill.
+- **Maturity:** 5 stars, 1 contributor, created 2026-03-20. Minimal.
+- **Limitation:** One platform pair only (Claude → Codex). No other targets.
+
+---
+
 ## Broader Frameworks
 
-These projects include skill portability as part of a larger system.
+These projects include skill portability as part of a larger system. Portability is a secondary concern.
 
-### 6. AI DevKit
+### 8. AI DevKit
 
 - **Repo:** [codeaholicguy/ai-devkit](https://github.com/codeaholicguy/ai-devkit)
 - **Site:** [ai-devkit.com](https://ai-devkit.com)
+- **Audience:** Consumer (primarily)
 - **Tagline:** "The toolkit for AI-assisted software development"
 - **Scope:** Universal CLI toolkit providing structured workflows, persistent memory, and reusable skills.
 - **Key features:**
@@ -101,9 +147,10 @@ These projects include skill portability as part of a larger system.
 - **Agents supported:** Claude Code, Copilot, Gemini CLI, Cursor, OpenCode, Antigravity, Codex (supported); Windsurf, Kilo Code, Roo Code, Amp (testing)
 - **Differentiator:** Broader than just portability — provides opinionated development workflows on top of portable skills.
 
-### 7. Everything Claude Code (ECC)
+### 9. Everything Claude Code (ECC)
 
 - **Repo:** [grishanin/everything-claude-code](https://github.com/grishanin/everything-claude-code)
+- **Audience:** Consumer (with author-adjacent patterns)
 - **Tagline:** "The agent harness performance optimization system"
 - **Scope:** Complete system: skills, instincts, memory optimization, continuous learning, security scanning, research-first development. Cross-platform is a secondary goal.
 - **Key features:**
@@ -114,11 +161,13 @@ These projects include skill portability as part of a larger system.
   - All hooks rewritten in Node.js for cross-OS compatibility (Windows, macOS, Linux)
   - Codex adapter drift guards and SessionStart fallback
 - **Agents supported:** Claude Code (primary), Codex, Cursor, OpenCode, Gemini CLI, Antigravity
-- **Differentiator:** Anthropic hackathon winner. Most battle-tested (10+ months daily use). Portability achieved through pragmatic adapter pattern rather than a universal abstraction. Claude Code is explicitly the primary target.
+- **Differentiator:** Anthropic hackathon winner. Most battle-tested (10+ months daily use). Portability achieved through pragmatic adapter pattern rather than a universal abstraction.
+- **Author relevance:** The adapter pattern is instructive for authors structuring their own repos, but ECC is a skill collection, not a tool for analysing or uplifting other plugins.
 
-### 8. AgentSys
+### 10. AgentSys
 
 - **Repo:** [agent-sh/agentsys](https://github.com/agent-sh/agentsys)
+- **Audience:** Consumer (with author infrastructure)
 - **Tagline:** "Write tools once, run everywhere"
 - **Scope:** Cross-platform library with unified utilities abstracting platform differences.
 - **Key features:**
@@ -127,11 +176,13 @@ These projects include skill portability as part of a larger system.
   - Slash commands as the primary interface (`/next-task`, `/ship`, `/deslop`, `/enhance`)
   - AI slop detection and cleanup
 - **Agents supported:** Claude Code (primary), OpenCode, Codex CLI, Cursor, Kiro
-- **Differentiator:** CI-driven lib sync across plugin repos. Each plugin repo gets its own `lib/` copy because Claude Code plugins are installed separately. Focus on workflow commands rather than raw skill portability.
+- **Differentiator:** CI-driven lib sync across plugin repos. Focus on workflow commands rather than raw skill portability.
+- **Author relevance:** The CI-driven sync is author infrastructure, but only for their own plugin ecosystem — not a general-purpose tool for other authors.
 
-### 9. agent-plugins-skills
+### 11. agent-plugins-skills
 
 - **Repo:** [richfrem/agent-plugins-skills](https://github.com/richfrem/agent-plugins-skills)
+- **Audience:** Consumer (with author-side quality tooling)
 - **Tagline:** "Universal upstream source for reusable AI agent plugins and skills"
 - **Scope:** Cross-platform skill library with an autonomous eval-gated evolution loop.
 - **Key features:**
@@ -142,6 +193,7 @@ These projects include skill portability as part of a larger system.
   - Skills must function in complete isolation — no sibling dependencies
 - **Agents supported:** Claude Code, Copilot, Gemini CLI, Antigravity, Roo Code, Windsurf, Cursor
 - **Differentiator:** Autonomous skill evolution loop is unique. Uses multi-agent layering (Claude → Gemini → Copilot) for cost-effective overnight skill improvement.
+- **Author relevance:** The eval-gated loop is author-side tooling, but focuses on quality improvement of existing skills, not on adding platform coverage.
 
 ---
 
@@ -149,25 +201,44 @@ These projects include skill portability as part of a larger system.
 
 Different angle on the same problem space.
 
-### 10. MCO (Multi-CLI Orchestrator)
+### 12. MCO (Multi-CLI Orchestrator)
 
 - **Repo:** [mco-org/mco](https://github.com/mco-org/mco)
+- **Audience:** Consumer
 - **Scope:** Dispatches prompts to multiple agent CLIs in parallel, aggregates results. Not about skill portability but about agent interoperability.
 - **Agents supported:** Claude Code, Codex CLI, Gemini CLI, OpenCode, Qwen Code
 - **Relevance:** Complementary — if skills are portable, MCO can orchestrate execution across agents.
 
-### 11. ZazenCodes Monorepo Approach
+### 13. ZazenCodes Monorepo Approach
 
 - **Source:** [Blog post](https://zazencodes.substack.com/p/cross-platform-agent-skills-guide) (April 2026)
+- **Audience:** Author (manual guidance)
 - **Scope:** Tutorial/guide on managing a central git repo of skills across agents. Not a tool — a pattern.
-- **Relevance:** Documents the manual version of what automated tools try to solve. Good for understanding user pain points and workflows.
+- **Relevance:** Documents the manual version of what automated tools try to solve. Good for understanding author pain points and workflows.
 
-### 12. AgentBridge
+### 14. AgentBridge
 
 - **Repo:** [catatafishen/agentbridge](https://github.com/catatafishen/agentbridge)
+- **Audience:** Consumer
 - **Scope:** JetBrains IDE plugin bridging 6 AI coding agents to 120+ IntelliJ platform APIs via MCP. Focused on IDE-side tooling rather than skill portability.
 - **Agents supported:** Copilot, Claude Code, Codex, Kiro, Junie, OpenCode
 - **Relevance:** Solves the "tool" side of portability (give agents access to IDE actions) rather than the "skill" side (portable instructions/workflows).
+
+---
+
+## Audience Summary
+
+| # | Project | Audience | Accepts any input platform | Gap analysis | Emits missing artifacts | Publishing guidance |
+|---|---------|----------|---------------------------|-------------|------------------------|-------------------|
+| 1 | SkillKit | Consumer | Yes (translate) | No | Yes (translate) | No |
+| 2 | Agentloom | Consumer | No (canonical .agents/) | No | Yes (sync) | No |
+| 3 | polyagent-skills | Consumer | No (convention) | No | No (manual) | No |
+| 4 | AllAgents | Consumer | No (registry) | No | Yes (sync) | No |
+| 5 | @agents-dev/cli | Consumer | No (canonical .agents/) | No | Yes (sync) | No |
+| 6 | acplugin | Author | Claude Code only | No | Yes (convert) | No |
+| 7 | claude-to-codex | Author | Claude Code only | No | Yes (convert) | No |
+| 8-11 | Frameworks | Consumer+ | Varies | No | Varies | No |
+| — | **skill-portability** | **Author** | **Yes (any platform)** | **Yes** | **Yes** | **Yes** |
 
 ---
 
@@ -204,20 +275,24 @@ Each agent expects skills in a specific location and format:
 
 ## Where skill-portability Sits
 
-Every project above falls into one of two categories:
+The landscape splits into three categories:
 
-1. **Deterministic CLI tools** (SkillKit, Agentloom, polyagent-skills, AllAgents, @agents-dev/cli) — external programs the user installs and runs. Some bundle directory services or registries. Several show signs of scope creep (SkillKit claiming 45 agents and 400K skills; Agentloom absorbing agents, commands, rules, MCP configs alongside skills).
+1. **Consumer sync tools** (SkillKit, Agentloom, polyagent-skills, AllAgents, @agents-dev/cli) — external CLIs that help users install and sync skills they found. Some bundle registries or marketplaces. The user is the person consuming skills, not the person who wrote them.
 
-2. **Broad frameworks** (ECC, AI DevKit, AgentSys, agent-plugins-skills) — skill portability is a secondary concern within a larger system for workflows, memory, eval loops, or performance optimization. Portability comes along for the ride but isn't the core value proposition.
+2. **One-directional author converters** (acplugin, claude-to-codex) — help authors convert FROM Claude Code to other platforms. Early stage (5-19 stars, single contributors). Cannot accept non-Claude input. No gap analysis — convert everything blindly without assessing what is actually missing.
 
-**skill-portability is neither.** It is:
+3. **Broad frameworks** (ECC, AI DevKit, AgentSys, agent-plugins-skills) — skill portability is a secondary concern within a larger system. Portability comes along for the ride but is not the core value proposition.
 
-- **A skill, not a CLI.** No install step, no binary, no sync daemon. The agent itself is the portability engine.
-- **Analysis-first.** Examines the existing plugin/repo, identifies what platform artifacts are present and missing, and reports findings.
-- **Optional uplift in-place.** If the user agrees, emits the missing artifacts directly into the project. No intermediate canonical format, no registry, no `.agents/` directory to maintain.
-- **Zero infrastructure.** No marketplace, no registry, no community layer. Just a skill that does one job: assess and optionally fill gaps.
+**skill-portability is the only project that:**
 
-This means skill-portability avoids the failure modes visible in the landscape:
+- **Targets authors specifically.** Every other tool either helps consumers sync/install, or converts blindly from one platform.
+- **Accepts any platform as input.** Not locked to Claude Code as the starting point. A Cursor plugin, a Codex skill, a bare SKILL.md — all valid inputs.
+- **Analyses before acting.** Assessment identifies what platform artifacts exist and what is missing, then reports findings before emitting anything.
+- **Emits native artifacts per platform.** No intermediate canonical format, no `.agents/` directory to maintain, no registry.
+- **Includes publishing guidance.** Generates PUBLISHING.md with per-platform publishing steps. No other project addresses the "how do I get this discovered and installed" question.
+- **Runs as a skill, not a CLI.** No install step, no binary, no sync daemon. The agent itself is the portability engine.
+
+### Failure modes skill-portability avoids
 
 | Failure mode | Examples | How skill-portability avoids it |
 |-------------|----------|-------------------------------|
@@ -226,5 +301,6 @@ This means skill-portability avoids the failure modes visible in the landscape:
 | Registry/marketplace maintenance burden | SkillKit, AllAgents | No registry; operates on whatever project is in front of it |
 | Canonical format lock-in | Agentloom (`.agents/`), polyagent-skills (adapters) | Emits native format per platform — no intermediate representation |
 | Requires ongoing sync | Agentloom, @agents-dev/cli | One-shot assessment and emission; no daemon or cron job |
-
-The closest analogue would be if someone took the "translate" function out of SkillKit, removed the CLI wrapper, and made it an agent skill that also does gap analysis. But no one has done that.
+| One-directional input | acplugin, claude-to-codex | Accepts any platform as starting point |
+| No gap analysis | acplugin, SkillKit translate | Assessment-first — identifies what is missing before emitting |
+| No publishing guidance | All others | Generates PUBLISHING.md with per-platform publishing steps |

--- a/docs/platforms/codex.md
+++ b/docs/platforms/codex.md
@@ -102,26 +102,52 @@ Two shapes:
 | Repo-local | `<repo>/plugins/<name>` | `<repo>/.agents/plugins/marketplace.json` |
 | Home-local | `~/plugins/<name>` | `~/.agents/plugins/marketplace.json` |
 
+### CLI marketplace commands
+
+```bash
+codex plugin marketplace add owner/repo
+codex plugin marketplace add owner/repo --ref main
+codex plugin marketplace remove marketplace-name
+codex plugin marketplace upgrade [marketplace-name]
+```
+
+### Built-in skill commands
+
+Codex ships with built-in skills for managing other skills:
+- `$skill-installer` — install skills from the curated catalog at `github.com/openai/skills` or by GitHub URL
+- `$skill-creator` — scaffold a new skill with guided prompts
+
 ## Skills system
 
 Codex supports the open SKILL.md standard.
 
 ### Skill discovery paths
 
-- `~/.codex/skills/<name>/SKILL.md`
-- `~/.agents/skills/<name>/SKILL.md`
-- Plugin-bundled `skills/` directory
+| Scope | Path |
+|-------|------|
+| Repo (closest) | `.agents/skills/` in current directory |
+| Repo (parents) | `.agents/skills/` in parent directories |
+| Repo (root) | `.agents/skills/` at repository root |
+| User | `~/.agents/skills/` |
+| User | `~/.codex/skills/` |
+| Admin | `/etc/codex/skills/` |
+| System | Bundled with Codex (e.g., `$skill-installer`, `$skill-creator`) |
+| Plugin-bundled | `skills/` directory in plugin |
 
 ### SKILL.md frontmatter
 
 `name` (required), `description` (required). Standard YAML frontmatter.
+
+### Invocation
+
+Skills can be invoked explicitly with the `$` prefix (`$skill-name`) or implicitly — Codex matches task descriptions to skill descriptions and loads matching skills automatically.
 
 ## Context files
 
 Codex uses `AGENTS.md` as its primary context file.
 
 - `AGENTS.md` at project root or in `.agents/` directories
-- Also reads `CLAUDE.md` as a fallback
+- The `project_doc_fallback_filenames` config key can be expanded to recognize alternate names. `CLAUDE.md` is not a documented default fallback.
 
 For Codex skill-discovery installs, `.codex/INSTALL.md` should document the install path.
 
@@ -167,6 +193,8 @@ Requires `multi_agent = true` in `~/.codex/config.toml`:
 [features]
 multi_agent = true
 ```
+
+As of 2026, multi-agent is enabled by default and no longer requires manual configuration.
 
 ### Environment detection
 

--- a/docs/platforms/copilot-cli.md
+++ b/docs/platforms/copilot-cli.md
@@ -69,10 +69,21 @@ For portability purposes, the repo's existing manifests for other platforms serv
 | Repository | `.github/skills/<name>/SKILL.md` |
 | Personal (CLI) | `~/.copilot/skills/<name>/SKILL.md` |
 | Cross-platform | `.claude/skills/`, `.agents/skills/` also discovered |
+| Cross-platform | `~/.claude/skills/`, `~/.agents/skills/` also discovered |
 
 Skills follow the open Agent Skills spec at agentskills.io — works across Copilot, Claude Code, Cursor, Codex, and Gemini.
 
-CLI commands: `gh skill install`, `gh skill update`, `gh skill publish`
+CLI commands (requires GitHub CLI v2.90.0+):
+- `gh skill install <owner/repo> [skill-name]` — install from GitHub
+- `gh skill install <owner/repo> <skill-name>@<tag>` — pin to version/tag/SHA
+- `gh skill search <keyword>` — find skills by keyword
+- `gh skill preview <owner/repo> <skill-name>` — inspect before installing (recommended for security)
+- `gh skill update [--all]` — check for and apply upstream changes
+- `gh skill publish [--fix]` — validate skills against the Agent Skills spec
+
+Key flags: `--agent` (target specific host), `--scope` (user or project), `--pin` (lock version).
+
+**Security:** GitHub does not vet third-party skills. Always run `gh skill preview` before installing skills from unknown sources.
 
 ## Context files and instructions
 
@@ -119,6 +130,10 @@ Skills follow the open SKILL.md standard with YAML frontmatter.
 `name` (required), `description` (required), `license` (optional).
 
 Copilot loads skills based on task relevance — the description drives when injection happens. All files in the skill directory are auto-discovered.
+
+### Invocation
+
+In Copilot CLI, invoke skills with the `/` prefix: `/skill-name`. Skills are also auto-routed by the agent based on task relevance.
 
 ### Prompt files (VS Code only)
 

--- a/docs/platforms/cursor.md
+++ b/docs/platforms/cursor.md
@@ -88,6 +88,7 @@ Three installation channels:
 | Marketplace | `cursor.com/marketplace` | Curated, manually reviewed, open-source only |
 | Local development | `~/.cursor/plugins/local/<name>/` | Restart required |
 | Team/Enterprise | Distribution groups | Admins set required/optional plugins |
+| GitHub install | `/add-plugin owner/repo` in Agent chat | Accepts shorthand or full URL |
 
 Plugins are Git repositories — no binaries shipped. Submission at `cursor.com/marketplace/publish`.
 
@@ -140,7 +141,7 @@ Four activation modes:
 | Agent-Requested | `false` | empty | set |
 | Manual | `false` | empty | empty |
 
-Important: the `globs` field is comma-separated, NOT a YAML array. Do not use brackets or quotes.
+The `globs` field accepts both comma-separated strings and YAML array syntax (e.g., `globs: ["pattern/**/*.ts"]`).
 
 Rule precedence: Team Rules > Project Rules > User Rules.
 
@@ -291,7 +292,7 @@ Cursor provides standard file, shell, and search tools. Tool names differ from C
 4. Not VS Code extensions — completely separate system
 5. MCP Resources not supported
 6. `.cursor-plugin/` is distinct from `.claude-plugin/` — copying without renaming fails
-7. `.mdc` frontmatter `globs` is comma-separated, not YAML array
+7. `.mdc` frontmatter `globs` accepts both comma-separated strings and YAML array syntax
 8. No dynamic plugin loading — restart required for changes
 9. Hook `additional_context` is snake_case (differs from Claude Code's camelCase)
 10. Cross-platform skill paths are one-way: Cursor reads `.claude/skills/` but not vice versa

--- a/docs/platforms/gemini-cli.md
+++ b/docs/platforms/gemini-cli.md
@@ -69,12 +69,16 @@ CLI commands:
 - `gemini extensions install <source>` — from GitHub repo or local path
 - `gemini extensions list` — list installed
 - `gemini extensions uninstall <name>` — remove
-- `gemini extensions activate|deactivate <name>` — toggle without uninstalling
+- `gemini extensions enable|disable <name> [--scope <scope>]` — toggle without uninstalling
 - `gemini extensions update [name]` — pull latest
-- `gemini extensions validate <path>` — validate manifest
-- `gemini extensions config <name> [setting]` — configure settings
+- `gemini extensions new <path> [template]` — scaffold new extension
+- `gemini extensions link <path>` — symlink for local development
 
 Extensions loaded at session start; changes require CLI restart.
+
+### Extensions gallery
+
+Gemini CLI has an extensions gallery at [geminicli.com/extensions](https://geminicli.com/extensions/) with 897+ extensions. Extensions are not vetted by Google — review before installing.
 
 ## Skills system
 
@@ -154,7 +158,7 @@ As of April 2026, `AGENTS.md` is included in the default context filename list a
 
 ## Hooks system
 
-Configured in `settings.json`, not in a standalone hooks.json file.
+Configured in `settings.json` for project/user scope, or `hooks/hooks.json` within extensions.
 
 ### Hook events (11)
 
@@ -327,7 +331,7 @@ No subagent dispatch tool — uses `@agent-name` syntax instead.
 5. Extension `name` must exactly match directory name (lowercase, dashes only)
 6. Extension policies cannot grant `allow` decisions
 7. Subagent frontmatter is mandatory — files without YAML frontmatter silently fail
-8. Hooks configured in `settings.json`, not a standalone `hooks.json`
+8. Hooks configured in `settings.json` for project/user scope, or `hooks/hooks.json` within extensions
 9. No `trust` option in extension MCP servers
 10. Hook event names use PascalCase (unlike Cursor's camelCase or Claude Code's PascalCase)
 

--- a/docs/platforms/opencode.md
+++ b/docs/platforms/opencode.md
@@ -126,7 +126,11 @@ metadata:               # optional, string-to-string map
 ---
 ```
 
-Invocation: agents invoke via the `skill` tool. Full content loads on demand. Permissions configurable: `allow`, `deny`, `ask`.
+### Invocation
+
+Mention a skill by name and the agent activates it automatically via the `skill` tool. Skills can also be listed with `/skills list` in the session. Full content loads on demand. Permissions configurable: `allow`, `deny`, `ask`.
+
+Skill names must be lowercase alphanumeric with hyphens only (regex: `^[a-z0-9]+(-[a-z0-9]+)*$`, 1–64 characters).
 
 ## Context files (instructions)
 
@@ -145,6 +149,13 @@ Search order:
 2. `.opencode/AGENTS.md` (loaded in addition to root-level files)
 3. Global `~/.config/opencode/AGENTS.md`
 4. Claude Code fallback `~/.claude/CLAUDE.md` (if no global `AGENTS.md`)
+
+### Disabling Claude Code compatibility
+
+Claude Code compatibility paths can be disabled via environment variables:
+- `OPENCODE_DISABLE_CLAUDE_CODE=1` — disables all Claude Code compat
+- `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1` — disables global `~/.claude/CLAUDE.md`
+- `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1` — disables `.claude/skills/` discovery
 
 Additional instruction files via config:
 ```json
@@ -247,6 +258,8 @@ Plugins can inject MCP servers programmatically via the `config` hook.
 | `webfetch` | `WebFetch` |
 | `question` | N/A (ask user) |
 | `skill` | `Skill` |
+| `apply_patch` | `Edit` (alternative) |
+| `lsp` | `LSP` |
 
 Tools use ripgrep under the hood and respect `.gitignore`.
 

--- a/docs/superpowers/plans/2026-04-24-publishing-wiring.md
+++ b/docs/superpowers/plans/2026-04-24-publishing-wiring.md
@@ -1,0 +1,369 @@
+# Publishing Wiring & README Audience Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update this repo's README to state its target audience, and wire PUBLISHING.md generation into the uplift skill so target plugins get author-facing publishing guidance.
+
+**Architecture:** Change A is a single README edit. Change B creates 8 new template files and adds Phase 6.4 + an extended README flag to the uplift skill. Templates follow the same `{{variable}}` pattern as existing install templates.
+
+**Tech Stack:** Markdown, pseudocode (SKILL.md)
+
+---
+
+### Task 1: Update README.md opening to state target audience
+
+**Files:**
+- Modify: `README.md:1-5`
+
+- [ ] **Step 1: Replace the opening two paragraphs**
+
+In `README.md`, replace:
+
+```markdown
+An agent skill — not a CLI, not a framework — that makes any plugin fully portable across all agent platforms.
+
+Point it at a plugin repo and it tells you what's missing. Say the word and it emits every missing artifact in place. No install step, no sync daemon, no registry. The agent itself is the portability engine.
+```
+
+With:
+
+```markdown
+A plugin for agent skill and plugin authors who have built for one platform — often Claude Code — and need to go cross-platform.
+
+Point it at a plugin repo and it tells you what's missing. Say the word and it emits every missing artifact in place — platform manifests, context files, tool mappings, install docs, and publishing guidance. No CLI to install, no sync daemon, no registry. The agent itself is the portability engine.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: update README opening to state target audience — plugin authors"
+```
+
+---
+
+### Task 2: Create PUBLISHING.md header template
+
+**Files:**
+- Create: `lib/templates/install-docs/publishing.md`
+
+- [ ] **Step 1: Write the header template**
+
+Create `lib/templates/install-docs/publishing.md`:
+
+```markdown
+# Publishing & Discoverability
+
+How to get **{{displayName}}** discovered and installed on each platform.
+
+See [INSTALL.md](INSTALL.md) for end-user installation instructions.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/templates/install-docs/publishing.md
+git commit -m "feat: add PUBLISHING.md header template"
+```
+
+---
+
+### Task 3: Create per-platform publishing templates
+
+**Files:**
+- Create: `lib/templates/install-docs/publishing/claude-code.md`
+- Create: `lib/templates/install-docs/publishing/cursor.md`
+- Create: `lib/templates/install-docs/publishing/gemini-cli.md`
+- Create: `lib/templates/install-docs/publishing/codex.md`
+- Create: `lib/templates/install-docs/publishing/copilot-cli.md`
+- Create: `lib/templates/install-docs/publishing/opencode.md`
+
+- [ ] **Step 1: Create Claude Code publishing template**
+
+Create `lib/templates/install-docs/publishing/claude-code.md`:
+
+```markdown
+## Claude Code
+
+No public marketplace — distribution is via Git repositories.
+
+### Publishing
+
+Create a `.claude-plugin/marketplace.json` in your repo. No submission or review process — any Git repo with a valid marketplace manifest can be consumed.
+
+### How users find and install {{displayName}}
+
+1. Register the marketplace: `/plugin marketplace add {{repository}}`
+2. Install: `/plugin install {{name}}@{{marketplaceName}}`
+
+### Team distribution
+
+Teams can auto-register the marketplace by adding to their project `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "{{marketplaceName}}": {
+      "source": {
+        "source": "github",
+        "repo": "{{repository}}"
+      }
+    }
+  }
+}
+```
+```
+
+- [ ] **Step 2: Create Cursor publishing template**
+
+Create `lib/templates/install-docs/publishing/cursor.md`:
+
+```markdown
+## Cursor
+
+Public marketplace at `cursor.com/marketplace` (curated, manually reviewed).
+
+### Publishing
+
+1. Ensure the plugin is open-source in a Git repository
+2. `.cursor-plugin/plugin.json` manifest must be present
+3. Submit at `cursor.com/marketplace/publish`
+4. Every plugin and update is manually reviewed
+
+### How users find and install {{displayName}}
+
+- Browse the marketplace at `cursor.com/marketplace`
+- In Agent chat: `/add-plugin {{repository}}`
+
+### Team distribution
+
+Cursor 2.6+ (Teams/Enterprise): admins import GitHub repos as team marketplaces via Dashboard Settings.
+```
+
+- [ ] **Step 3: Create Gemini CLI publishing template**
+
+Create `lib/templates/install-docs/publishing/gemini-cli.md`:
+
+```markdown
+## Gemini CLI
+
+Extensions gallery at [geminicli.com/extensions](https://geminicli.com/extensions/).
+
+### Publishing
+
+Publish as a GitHub repository with a `gemini-extension.json` manifest (requires `name`, `version`, `description`). Extensions are not vetted by Google.
+
+### How users find and install {{displayName}}
+
+```bash
+gemini extensions install {{repository}}
+```
+
+Users can browse the gallery or install directly from the GitHub URL.
+```
+
+- [ ] **Step 4: Create Codex publishing template**
+
+Create `lib/templates/install-docs/publishing/codex.md`:
+
+```markdown
+## Codex
+
+Two publishing paths — choose based on what you're distributing.
+
+### Skill discovery (lightweight)
+
+For repos that are mostly instructions with no plugin UI metadata:
+
+- Submit a PR to `github.com/openai/skills` for inclusion in the curated catalog
+- Or publish as a standalone GitHub repo — users install via `$skill-installer install {{repository}}`
+
+### Plugin packaging (full)
+
+For first-class plugin packages with marketplace metadata:
+
+- Create `.codex-plugin/plugin.json` and a `marketplace.json` listing the plugin
+- Users register via `codex plugin marketplace add {{repository}}`
+- Public self-serve plugin publishing is coming soon per OpenAI docs
+
+### How users find and install {{displayName}}
+
+**Skills path:**
+```bash
+$skill-installer install {{repository}}
+```
+
+**Plugin path:**
+```bash
+codex plugin marketplace add {{repository}}
+```
+```
+
+- [ ] **Step 5: Create Copilot CLI publishing template**
+
+Create `lib/templates/install-docs/publishing/copilot-cli.md`:
+
+```markdown
+## Copilot CLI
+
+Skills published via GitHub CLI (v2.90.0+).
+
+### Publishing
+
+```bash
+gh skill publish [--fix]
+```
+
+Validates against the Agent Skills spec. No formal review — skills are published to the GitHub repository.
+
+### How users find and install {{displayName}}
+
+```bash
+gh skill search {{name}}
+gh skill preview {{repository}} {{name}}
+gh skill install {{repository}}
+```
+
+### Third-party registries
+
+- [skills.sh](https://skills.sh) — community directory with 300k+ monthly views
+- [github/awesome-copilot](https://github.com/github/awesome-copilot) — GitHub's curated collection
+
+### Security note
+
+Always recommend users run `gh skill preview` before installing. GitHub does not vet third-party skills.
+```
+
+- [ ] **Step 6: Create OpenCode publishing template**
+
+Create `lib/templates/install-docs/publishing/opencode.md`:
+
+```markdown
+## OpenCode
+
+No marketplace. Distribution via npm or filesystem.
+
+### Publishing
+
+Publish the plugin as an npm package. No submission or review process.
+
+### How users find and install {{displayName}}
+
+**npm:**
+Add to `opencode.json`:
+```json
+{
+  "plugin": ["{{name}}"]
+}
+```
+
+**Local files:**
+Copy `.opencode/plugins/{{name}}.js` to `.opencode/plugins/` (project) or `~/.config/opencode/plugins/` (global).
+
+Requires [Bun](https://bun.sh) for plugin loading.
+```
+
+- [ ] **Step 7: Commit all 6 templates**
+
+```bash
+git add lib/templates/install-docs/publishing/
+git commit -m "feat: add per-platform publishing templates for PUBLISHING.md generation"
+```
+
+---
+
+### Task 4: Wire Phase 6.4 and README flag into uplift skill
+
+**Files:**
+- Modify: `skills/uplifting-a-plugin/SKILL.md:476-529`
+
+- [ ] **Step 1: Add Phase 6.4 after Phase 6.3**
+
+In `skills/uplifting-a-plugin/SKILL.md`, after the closing ` ``` ` of Phase 6.3's WRITE_INSTALL_DOCS pseudocode block (line 529), and before the `---` separator, insert:
+
+```markdown
+
+### 6.4 Write Publishing Docs
+
+```pseudocode
+WRITE_PUBLISHING_DOCS(computed, platforms_with_artifacts):
+  header = render(Read("lib/templates/install-docs/publishing.md"), computed.metadata)
+  sections = ""
+  FOR platform IN platforms_with_artifacts:
+    template = read_if_exists("lib/templates/install-docs/publishing/" + platform + ".md")
+    IF template:
+      sections += render(template, computed.metadata) + "\n\n"
+
+  IF sections:
+    content = header + "\n\n" + sections
+    Write("PUBLISHING.md", content)
+    computed.created.append({ path: "PUBLISHING.md", platform: "cross" })
+```
+```
+
+- [ ] **Step 2: Extend the README flag in Phase 6.3**
+
+In `skills/uplifting-a-plugin/SKILL.md`, find the README flag block (lines 522-528):
+
+```pseudocode
+  # Flag missing Installation section in README
+  IF file_exists("README.md"):
+    readme = Read("README.md")
+    IF "## Installation" NOT IN readme AND "## Install" NOT IN readme:
+      computed.flagged.append(
+        "README.md — no Installation section found. Add install instructions or link to INSTALL.md."
+      )
+```
+
+Replace with:
+
+```pseudocode
+  # Flag missing Installation and Publishing sections in README
+  IF file_exists("README.md"):
+    readme = Read("README.md")
+    IF "## Installation" NOT IN readme AND "## Install" NOT IN readme:
+      computed.flagged.append(
+        "README.md — no Installation section found. Add install instructions or link to INSTALL.md."
+      )
+    IF "PUBLISHING.md" NOT IN readme:
+      computed.flagged.append(
+        "README.md — no link to PUBLISHING.md. Add a link so plugin authors can find publishing guidance."
+      )
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/uplifting-a-plugin/SKILL.md
+git commit -m "feat: wire PUBLISHING.md generation into uplift Phase 6.4 with README flag"
+```
+
+---
+
+### Task 5: Verify and final commit
+
+- [ ] **Step 1: Verify template directory structure**
+
+Run: `find lib/templates/install-docs/publishing -type f | sort`
+
+Expected:
+```
+lib/templates/install-docs/publishing/claude-code.md
+lib/templates/install-docs/publishing/codex.md
+lib/templates/install-docs/publishing/copilot-cli.md
+lib/templates/install-docs/publishing/cursor.md
+lib/templates/install-docs/publishing/gemini-cli.md
+lib/templates/install-docs/publishing/opencode.md
+```
+
+- [ ] **Step 2: Verify Phase 6.4 exists in skill**
+
+Run: `grep -n "6.4\|WRITE_PUBLISHING_DOCS\|PUBLISHING.md" skills/uplifting-a-plugin/SKILL.md`
+
+Expected: matches for Phase 6.4 header, function name, and PUBLISHING.md references.
+
+- [ ] **Step 3: Verify README opening mentions authors**
+
+Run: `head -3 README.md`
+
+Expected: first line is `# Skill Portability`, second line is empty, third starts with `A plugin for agent skill and plugin authors`.

--- a/docs/superpowers/specs/2026-04-24-publishing-discoverability-design.md
+++ b/docs/superpowers/specs/2026-04-24-publishing-discoverability-design.md
@@ -1,0 +1,114 @@
+# Publishing & Discoverability Reference Doc
+
+**Date:** 2026-04-24
+
+## Problem
+
+Marketplace publishing and discoverability information is scattered across 6 platform docs. The uplift skill can generate all the platform artifacts, but there's no consolidated reference for advising plugin authors on how to actually get their plugin discovered and installed on each platform.
+
+## Scope
+
+One new file: `lib/patterns/platforms/publishing-and-discoverability.md`
+
+This is a patterns file in `lib/patterns/platforms/` where the skills already read platform-specific guidance. The uplift skill will use this when generating install documentation and advising on publishing steps for target plugins.
+
+## Structure
+
+Per platform, cover:
+1. **Where to publish** — marketplace URL, CLI command, or filesystem convention
+2. **Requirements** — open-source, manifest fields, review process, submission steps
+3. **How users discover it** — search, browse, CLI commands
+4. **How users install it** — exact commands/steps (full flow, not just prerequisites)
+5. **Third-party registries** — if relevant (skills.sh, geminicli.com/extensions, etc.)
+6. **Team/org distribution** — how to share within a team without going through a public marketplace
+
+## Platform Coverage
+
+### Claude Code
+
+- No public marketplace/gallery — distribution is via Git repos
+- Authors create `marketplace.json` in their repo
+- Users register the marketplace: `/plugin marketplace add owner/repo`
+- Users then install: `/plugin install plugin-name@marketplace-name`
+- Team distribution: `extraKnownMarketplaces` in project `.claude/settings.json` (object format with `source.source: "github"`)
+- npm source type also supported in marketplace entries
+
+### Cursor
+
+- Public marketplace at `cursor.com/marketplace` (curated, manually reviewed)
+- Requirements: open-source, Git repository, `.cursor-plugin/plugin.json` manifest
+- Submission at `cursor.com/marketplace/publish`
+- Users can also install from GitHub via `/add-plugin owner/repo` in Agent chat
+- Team/Enterprise: admins import GitHub repos as team marketplaces via Dashboard Settings
+- Local dev: symlink to `~/.cursor/plugins/local/<name>/`
+
+### Gemini CLI
+
+- Extensions gallery at `geminicli.com/extensions` (897+ extensions)
+- Not vetted by Google — users should review before installing
+- Requirements: `gemini-extension.json` manifest with name, version, description
+- Users install via `gemini extensions install <github-url>`
+- Local dev via `gemini extensions link <path>`
+- Official extensions org at `github.com/gemini-cli-extensions`
+
+### Codex — Skill Discovery Path
+
+For repos that are mostly instructions with no plugin UI metadata:
+
+- Official curated catalog at `github.com/openai/skills` (`.curated/` and `.experimental/` folders)
+- Authors submit PRs to `github.com/openai/skills` for inclusion
+- Users install via `$skill-installer` built-in skill (by name from `.curated` or by GitHub URL)
+- Users can also clone and symlink: `ln -s skills/ ~/.agents/skills/<name>`
+- Required artifacts: `skills/<name>/SKILL.md` with name and description frontmatter
+
+### Codex — Plugin Packaging Path
+
+For first-class plugin packages with marketplace metadata:
+
+- Plugin marketplace via `codex plugin marketplace add owner/repo`
+- Repo-local marketplace: `.agents/plugins/marketplace.json`
+- Home-local marketplace: `~/.agents/plugins/marketplace.json`
+- Required artifacts: `.codex-plugin/plugin.json`, `marketplace.json` with plugin entries
+- Public self-serve plugin publishing is "coming soon" per OpenAI docs
+
+### Copilot CLI
+
+- `gh skill publish [--fix]` validates and publishes skills (requires GitHub CLI v2.90.0+)
+- `gh skill search <keyword>` for discovery
+- `gh skill install <owner/repo> [skill-name]` for installation
+- Third-party registry: skills.sh (300k+ monthly views, 1000+ skills)
+- GitHub's curated collection: `github/awesome-copilot`
+- Security: 36.82% of third-party skills have security issues (Snyk "ToxicSkills" study) — always `gh skill preview` first
+- GitHub Marketplace for server-side Copilot Extensions (separate from file-based skills)
+
+### OpenCode
+
+- No marketplace — distribution is via npm packages or filesystem
+- npm: add package name to `"plugin"` array in `opencode.json`, Bun auto-installs
+- Filesystem: drop `.js`/`.ts` into `.opencode/plugins/` or `~/.config/opencode/plugins/`
+- Skills discovered from `.opencode/skills/`, `.agents/skills/`, `.claude/skills/` (compatibility)
+- No submission or review process — publish to npm and document install
+
+## Summary Table
+
+Include a quick-reference table at the top of the doc:
+
+| Platform | Public marketplace | Submission | Review | Discovery | Install |
+|----------|--------------------|------------|--------|-----------|---------|
+| Claude Code | No (Git repos) | N/A | N/A | Share repo URL | 1. `/plugin marketplace add owner/repo` 2. `/plugin install name@marketplace` |
+| Cursor | cursor.com/marketplace | cursor.com/marketplace/publish | Manual, open-source only | Marketplace search or `/add-plugin` | `/add-plugin owner/repo` |
+| Gemini CLI | geminicli.com/extensions | Via gallery | Not vetted | Gallery search | `gemini extensions install <url>` |
+| Codex (skills) | github.com/openai/skills | PR to repo | Curated | `$skill-installer` search | `$skill-installer <name>` |
+| Codex (plugins) | Not yet public | N/A | N/A | `codex plugin marketplace add` | Via marketplace |
+| Copilot CLI | skills.sh (3rd party) | `gh skill publish` | Not vetted | `gh skill search` | `gh skill install owner/repo` |
+| OpenCode | npm | `npm publish` | N/A | npm search | Add to `opencode.json` `"plugin"` array |
+
+## Files changed
+
+- Create: `lib/patterns/platforms/publishing-and-discoverability.md`
+
+## Files not changed
+
+- `docs/platforms/` — existing platform docs stay as-is; this new file lives in `lib/patterns/platforms/` where skills read from
+- Skills — no changes to skill logic in this spec (skill wiring is a follow-up)
+- INSTALL.md, README.md — these document skill-portability's own install, not target plugin publishing

--- a/docs/superpowers/specs/2026-04-24-publishing-wiring-design.md
+++ b/docs/superpowers/specs/2026-04-24-publishing-wiring-design.md
@@ -1,0 +1,114 @@
+# Publishing Wiring & README Audience Fix
+
+**Date:** 2026-04-24
+
+## Problem
+
+1. skill-portability's README doesn't state its target audience — plugin authors who have skills/plugins for one platform (often Claude Code) and want to go cross-platform.
+2. The uplift skill generates INSTALL.md (consumer-facing) but no publishing guidance (author-facing). The publishing reference exists at `lib/patterns/platforms/publishing-and-discoverability.md` but nothing reads it.
+
+## Scope
+
+Two independent changes:
+
+### Change A: Fix this repo's README.md
+
+Update the opening of `README.md` to clearly state the target audience: plugin authors.
+
+Replace:
+```markdown
+An agent skill — not a CLI, not a framework — that makes any plugin fully portable across all agent platforms.
+
+Point it at a plugin repo and it tells you what's missing. Say the word and it emits every missing artifact in place. No install step, no sync daemon, no registry. The agent itself is the portability engine.
+```
+
+With:
+```markdown
+A plugin for agent skill and plugin authors who have built for one platform — often Claude Code — and need to go cross-platform.
+
+Point it at a plugin repo and it tells you what's missing. Say the word and it emits every missing artifact in place — platform manifests, context files, tool mappings, install docs, and publishing guidance. No CLI to install, no sync daemon, no registry. The agent itself is the portability engine.
+```
+
+### Change B: Wire PUBLISHING.md into the uplift skill
+
+Three sub-parts:
+
+#### B1. New template: `lib/templates/install-docs/publishing.md`
+
+A template for the generated `PUBLISHING.md` that the uplift skill writes to target plugins. Uses the same `{{variable}}` substitution as the install templates.
+
+Structure:
+```markdown
+# Publishing & Discoverability
+
+How to get {{displayName}} discovered and installed on each platform.
+
+{per-platform sections, filtered to target_platforms}
+```
+
+Per-platform sections are distilled from `lib/patterns/platforms/publishing-and-discoverability.md` into template form with `{{name}}`, `{{displayName}}`, `{{repository}}`, `{{marketplaceName}}` variables.
+
+Each platform section covers:
+- Where to publish / submit
+- How users discover it
+- How users install it
+- Team/org distribution (if applicable)
+
+#### B2. New Phase 6.4 in uplift skill
+
+Add after Phase 6.3 (WRITE_INSTALL_DOCS):
+
+```pseudocode
+WRITE_PUBLISHING_DOCS(computed, platforms_with_artifacts):
+  sections = ""
+  FOR platform IN platforms_with_artifacts:
+    template = read_if_exists("lib/templates/install-docs/publishing/" + platform + ".md")
+    IF template:
+      sections += render(template, computed.metadata) + "\n\n"
+
+  IF sections:
+    content = render(Read("lib/templates/install-docs/publishing.md"), computed.metadata)
+    content += sections
+    Write("PUBLISHING.md", content)
+    computed.created.append({ path: "PUBLISHING.md", platform: "cross" })
+```
+
+Template directory: `lib/templates/install-docs/publishing/` with one file per platform (same pattern as `adding-platform/`).
+
+#### B3. Extend Phase 6.3 README flag
+
+Update the existing README flag (lines 522-528) to also check for a PUBLISHING.md link:
+
+```pseudocode
+  IF file_exists("README.md"):
+    readme = Read("README.md")
+    IF "## Installation" NOT IN readme AND "## Install" NOT IN readme:
+      computed.flagged.append(
+        "README.md — no Installation section found. Add install instructions or link to INSTALL.md."
+      )
+    IF "PUBLISHING.md" NOT IN readme:
+      computed.flagged.append(
+        "README.md — no link to PUBLISHING.md. Add a link so plugin authors can find publishing guidance."
+      )
+```
+
+## Files created
+
+- `lib/templates/install-docs/publishing.md` — header template for PUBLISHING.md
+- `lib/templates/install-docs/publishing/claude-code.md`
+- `lib/templates/install-docs/publishing/cursor.md`
+- `lib/templates/install-docs/publishing/gemini-cli.md`
+- `lib/templates/install-docs/publishing/codex.md`
+- `lib/templates/install-docs/publishing/copilot-cli.md`
+- `lib/templates/install-docs/publishing/opencode.md`
+
+## Files modified
+
+- `README.md` — update opening to state target audience
+- `skills/uplifting-a-plugin/SKILL.md` — add Phase 6.4 (WRITE_PUBLISHING_DOCS), extend Phase 6.3 README flag
+
+## Files not changed
+
+- `lib/patterns/platforms/publishing-and-discoverability.md` — stays as raw reference; templates distill it
+- `skills/assessing-plugin-portability/SKILL.md` — assessment doesn't generate docs
+- `INSTALL.md` — documents skill-portability's own install, unrelated

--- a/lib/patterns/platforms/publishing-and-discoverability.md
+++ b/lib/patterns/platforms/publishing-and-discoverability.md
@@ -1,0 +1,227 @@
+# Publishing & Discoverability
+
+How to get a plugin discovered and installed on each platform. Use this reference when generating install documentation and advising plugin authors on publishing steps.
+
+## Quick Reference
+
+| Platform | Public marketplace | Submission | Review | Discovery | Install |
+|----------|--------------------|------------|--------|-----------|---------|
+| Claude Code | No (Git repos) | N/A | N/A | Share repo URL | 1. `/plugin marketplace add owner/repo` 2. `/plugin install name@marketplace` |
+| Cursor | cursor.com/marketplace | cursor.com/marketplace/publish | Manual, open-source only | Marketplace search or `/add-plugin` | `/add-plugin owner/repo` |
+| Gemini CLI | geminicli.com/extensions | Via gallery | Not vetted | Gallery search | `gemini extensions install <url>` |
+| Codex (skills) | github.com/openai/skills | PR to repo | Curated | `$skill-installer` search | `$skill-installer <name>` |
+| Codex (plugins) | Not yet public | N/A | N/A | `codex plugin marketplace add` | Via marketplace |
+| Copilot CLI | skills.sh (3rd party) | `gh skill publish` | Not vetted | `gh skill search` | `gh skill install owner/repo` |
+| OpenCode | npm | `npm publish` | N/A | npm search | Add to `opencode.json` `"plugin"` array |
+
+## Claude Code
+
+No public marketplace or gallery. Distribution is via Git repositories.
+
+### Publishing
+
+Authors create a `.claude-plugin/marketplace.json` in their repo listing the plugins it contains. There is no submission or review process — any Git repo with a valid marketplace manifest can be consumed.
+
+Marketplace entry sources:
+- `"source": "github"` with `"repo": "owner/repo"`
+- `"source": "url"` with a Git URL
+- `"source": "git-subdir"` for monorepos
+- `"source": "npm"` for npm-published packages
+
+### Discovery and install
+
+Users register the marketplace, then install:
+
+```
+/plugin marketplace add owner/repo
+/plugin install plugin-name@marketplace-name
+```
+
+### Team distribution
+
+Add to project `.claude/settings.json` so teammates get the marketplace automatically:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "marketplace-name": {
+      "source": {
+        "source": "github",
+        "repo": "owner/repo"
+      }
+    }
+  }
+}
+```
+
+Can also auto-enable plugins via `"enabledPlugins"` in the same settings file.
+
+## Cursor
+
+Public marketplace at `cursor.com/marketplace`. Curated and manually reviewed.
+
+### Publishing
+
+1. Plugin must be open-source in a Git repository
+2. `.cursor-plugin/plugin.json` manifest required (minimum: `name` field)
+3. Submit at `cursor.com/marketplace/publish`
+4. Every plugin and update is manually reviewed
+
+### Discovery and install
+
+- Browse the marketplace at `cursor.com/marketplace`
+- In Agent chat: `/add-plugin owner/repo` (GitHub shorthand or full URL)
+
+### Team distribution
+
+Cursor 2.6+ (Teams/Enterprise plans): admins import GitHub repos as team marketplaces via Dashboard Settings. Admins set plugins as required or optional.
+
+### Local development
+
+Symlink to `~/.cursor/plugins/local/<name>/`. Restart required (Developer: Reload Window).
+
+## Gemini CLI
+
+Extensions gallery at [geminicli.com/extensions](https://geminicli.com/extensions/) with 897+ extensions.
+
+### Publishing
+
+Extensions are published as GitHub repositories. The gallery lists them but Google does not vet, endorse, or guarantee functionality or security. Users should review extensions before installing.
+
+Official extensions org: `github.com/gemini-cli-extensions` (43+ repos from Google).
+
+### Requirements
+
+`gemini-extension.json` manifest with `name`, `version`, and `description` fields.
+
+### Discovery and install
+
+- Browse the gallery at `geminicli.com/extensions`
+- Install: `gemini extensions install <github-url>`
+- Install with version pin: `gemini extensions install <url> --ref <tag>`
+
+### Local development
+
+`gemini extensions link <path>` creates a symlink for local dev. Changes require CLI restart.
+
+## Codex — Skill Discovery Path
+
+For repos that are mostly instructions with no plugin UI metadata needed.
+
+### Publishing
+
+- Submit a PR to `github.com/openai/skills` for inclusion in the curated catalog
+- Skills go into `.curated/` (vetted) or `.experimental/` (community/developmental)
+- Alternatively, publish as a standalone GitHub repo
+
+### Requirements
+
+`skills/<name>/SKILL.md` with `name` and `description` in YAML frontmatter.
+
+### Discovery and install
+
+- `$skill-installer <name>` — install from the curated catalog by name
+- `$skill-installer install <name> from the .experimental folder`
+- `$skill-installer install <github-url>` — install by URL
+- Manual: clone and symlink `skills/` to `~/.agents/skills/<name>`
+
+Skills install into `~/.codex/skills/<name>/` by default.
+
+### Third-party registries
+
+SkillsMP.com and Smithery.ai have emerged as community skill directories.
+
+## Codex — Plugin Packaging Path
+
+For first-class plugin packages with marketplace metadata and bundled components (hooks, MCP, apps).
+
+### Publishing
+
+Public self-serve plugin publishing is "coming soon" per OpenAI docs. Currently, plugins are distributed via Git repos with marketplace manifests.
+
+### Requirements
+
+- `.codex-plugin/plugin.json` manifest
+- `marketplace.json` listing the plugin with source path, description, version
+
+### Discovery and install
+
+- Register a marketplace source: `codex plugin marketplace add owner/repo`
+- Also accepts: `--ref <branch>`, `--sparse <path>`, SSH URLs, local paths
+- Repo-local marketplace: `<repo>/.agents/plugins/marketplace.json`
+- Home-local marketplace: `~/.agents/plugins/marketplace.json`
+
+### Upgrade
+
+`codex plugin marketplace upgrade [marketplace-name]`
+
+## Copilot CLI
+
+Skills published and discovered via GitHub CLI (v2.90.0+).
+
+### Publishing
+
+```bash
+gh skill publish [--fix]
+```
+
+Validates skills against the Agent Skills specification. No formal review — skills are published to the GitHub repository.
+
+### Requirements
+
+`skills/<name>/SKILL.md` with `name` and `description` in YAML frontmatter.
+
+### Discovery and install
+
+```bash
+gh skill search <keyword>
+gh skill preview owner/repo skill-name    # inspect before installing
+gh skill install owner/repo [skill-name]
+gh skill install owner/repo skill-name@tag  # pin to version
+```
+
+Key flags: `--agent` (target specific host), `--scope` (user or project), `--pin` (lock version).
+
+### Security
+
+GitHub does not vet third-party skills. A Snyk study ("ToxicSkills") found that 36.82% of 3,984 skills from third-party registries carry security issues (prompt injections, hidden instructions, malicious scripts). Always run `gh skill preview` before installing.
+
+### Third-party registries
+
+- **skills.sh** — 300k+ monthly views, 1000+ skills with install counts
+- **github/awesome-copilot** — GitHub's curated community collection
+- **tech-leads-club/agent-skills** — "secure, validated skill registry"
+- **VoltAgent/awesome-agent-skills** — 1000+ curated skills
+
+### Server-side extensions
+
+GitHub Marketplace also hosts server-side Copilot Extensions (invoked via `@extension-name`). These are GitHub App-based integrations requiring HTTPS endpoints — separate from file-based skills.
+
+## OpenCode
+
+No marketplace. Distribution via npm packages or filesystem.
+
+### Publishing
+
+Publish the plugin as an npm package. No submission or review process.
+
+### Requirements
+
+Plugin is a `.js` or `.ts` file exporting plugin functions. For npm distribution, standard `package.json` with the plugin as the entry point.
+
+### Discovery and install
+
+**npm packages:**
+Add to `opencode.json`:
+```json
+{
+  "plugin": ["package-name"]
+}
+```
+Bun auto-installs at startup. Cached in `~/.cache/opencode/node_modules/`.
+
+**Local files:**
+Drop `.js`/`.ts` into `.opencode/plugins/` (project) or `~/.config/opencode/plugins/` (global). Auto-loaded at startup.
+
+**Skills:**
+Discovered from `.opencode/skills/`, `.agents/skills/`, `.claude/skills/` (compatibility). No install step — filesystem placement is sufficient.

--- a/lib/templates/install-docs/publishing.md
+++ b/lib/templates/install-docs/publishing.md
@@ -1,0 +1,5 @@
+# Publishing & Discoverability
+
+How to get **{{displayName}}** discovered and installed on each platform.
+
+See [INSTALL.md](INSTALL.md) for end-user installation instructions.

--- a/lib/templates/install-docs/publishing/claude-code.md
+++ b/lib/templates/install-docs/publishing/claude-code.md
@@ -1,0 +1,29 @@
+## Claude Code
+
+No public marketplace — distribution is via Git repositories.
+
+### Publishing
+
+Create a `.claude-plugin/marketplace.json` in your repo. No submission or review process — any Git repo with a valid marketplace manifest can be consumed.
+
+### How users find and install {{displayName}}
+
+1. Register the marketplace: `/plugin marketplace add {{repository}}`
+2. Install: `/plugin install {{name}}@{{marketplaceName}}`
+
+### Team distribution
+
+Teams can auto-register the marketplace by adding to their project `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "{{marketplaceName}}": {
+      "source": {
+        "source": "github",
+        "repo": "{{repository}}"
+      }
+    }
+  }
+}
+```

--- a/lib/templates/install-docs/publishing/codex.md
+++ b/lib/templates/install-docs/publishing/codex.md
@@ -1,0 +1,30 @@
+## Codex
+
+Two publishing paths — choose based on what you're distributing.
+
+### Skill discovery (lightweight)
+
+For repos that are mostly instructions with no plugin UI metadata:
+
+- Submit a PR to `github.com/openai/skills` for inclusion in the curated catalog
+- Or publish as a standalone GitHub repo — users install via `$skill-installer install {{repository}}`
+
+### Plugin packaging (full)
+
+For first-class plugin packages with marketplace metadata:
+
+- Create `.codex-plugin/plugin.json` and a `marketplace.json` listing the plugin
+- Users register via `codex plugin marketplace add {{repository}}`
+- Public self-serve plugin publishing is coming soon per OpenAI docs
+
+### How users find and install {{displayName}}
+
+**Skills path:**
+```bash
+$skill-installer install {{repository}}
+```
+
+**Plugin path:**
+```bash
+codex plugin marketplace add {{repository}}
+```

--- a/lib/templates/install-docs/publishing/copilot-cli.md
+++ b/lib/templates/install-docs/publishing/copilot-cli.md
@@ -1,0 +1,28 @@
+## Copilot CLI
+
+Skills published via GitHub CLI (v2.90.0+).
+
+### Publishing
+
+```bash
+gh skill publish [--fix]
+```
+
+Validates against the Agent Skills spec. No formal review — skills are published to the GitHub repository.
+
+### How users find and install {{displayName}}
+
+```bash
+gh skill search {{name}}
+gh skill preview {{repository}} {{name}}
+gh skill install {{repository}}
+```
+
+### Third-party registries
+
+- [skills.sh](https://skills.sh) — community directory with 300k+ monthly views
+- [github/awesome-copilot](https://github.com/github/awesome-copilot) — GitHub's curated collection
+
+### Security note
+
+Always recommend users run `gh skill preview` before installing. GitHub does not vet third-party skills.

--- a/lib/templates/install-docs/publishing/cursor.md
+++ b/lib/templates/install-docs/publishing/cursor.md
@@ -1,0 +1,19 @@
+## Cursor
+
+Public marketplace at `cursor.com/marketplace` (curated, manually reviewed).
+
+### Publishing
+
+1. Ensure the plugin is open-source in a Git repository
+2. `.cursor-plugin/plugin.json` manifest must be present
+3. Submit at `cursor.com/marketplace/publish`
+4. Every plugin and update is manually reviewed
+
+### How users find and install {{displayName}}
+
+- Browse the marketplace at `cursor.com/marketplace`
+- In Agent chat: `/add-plugin {{repository}}`
+
+### Team distribution
+
+Cursor 2.6+ (Teams/Enterprise): admins import GitHub repos as team marketplaces via Dashboard Settings.

--- a/lib/templates/install-docs/publishing/gemini-cli.md
+++ b/lib/templates/install-docs/publishing/gemini-cli.md
@@ -1,0 +1,15 @@
+## Gemini CLI
+
+Extensions gallery at [geminicli.com/extensions](https://geminicli.com/extensions/).
+
+### Publishing
+
+Publish as a GitHub repository with a `gemini-extension.json` manifest (requires `name`, `version`, `description`). Extensions are not vetted by Google.
+
+### How users find and install {{displayName}}
+
+```bash
+gemini extensions install {{repository}}
+```
+
+Users can browse the gallery or install directly from the GitHub URL.

--- a/lib/templates/install-docs/publishing/opencode.md
+++ b/lib/templates/install-docs/publishing/opencode.md
@@ -1,0 +1,22 @@
+## OpenCode
+
+No marketplace. Distribution via npm or filesystem.
+
+### Publishing
+
+Publish the plugin as an npm package. No submission or review process.
+
+### How users find and install {{displayName}}
+
+**npm:**
+Add to `opencode.json`:
+```json
+{
+  "plugin": ["{{name}}"]
+}
+```
+
+**Local files:**
+Copy `.opencode/plugins/{{name}}.js` to `.opencode/plugins/` (project) or `~/.config/opencode/plugins/` (global).
+
+Requires [Bun](https://bun.sh) for plugin loading.

--- a/skills/uplifting-a-plugin/SKILL.md
+++ b/skills/uplifting-a-plugin/SKILL.md
@@ -519,13 +519,34 @@ WRITE_INSTALL_DOCS(computed, sections, platforms_with_artifacts):
     Write(".codex/INSTALL.md", "See [INSTALL.md](../INSTALL.md) for installation instructions.\n")
     computed.created.append({ path: ".codex/INSTALL.md", platform: "codex" })
 
-  # Flag missing Installation section in README
+  # Flag missing Installation and Publishing sections in README
   IF file_exists("README.md"):
     readme = Read("README.md")
     IF "## Installation" NOT IN readme AND "## Install" NOT IN readme:
       computed.flagged.append(
         "README.md — no Installation section found. Add install instructions or link to INSTALL.md."
       )
+    IF "PUBLISHING.md" NOT IN readme:
+      computed.flagged.append(
+        "README.md — no link to PUBLISHING.md. Add a link so plugin authors can find publishing guidance."
+      )
+```
+
+### 6.4 Write Publishing Docs
+
+```pseudocode
+WRITE_PUBLISHING_DOCS(computed, platforms_with_artifacts):
+  header = render(Read("lib/templates/install-docs/publishing.md"), computed.metadata)
+  sections = ""
+  FOR platform IN platforms_with_artifacts:
+    template = read_if_exists("lib/templates/install-docs/publishing/" + platform + ".md")
+    IF template:
+      sections += render(template, computed.metadata) + "\n\n"
+
+  IF sections:
+    content = header + "\n\n" + sections
+    Write("PUBLISHING.md", content)
+    computed.created.append({ path: "PUBLISHING.md", platform: "cross" })
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **Competitive landscape research** — catalogued 12 projects in the cross-platform skill portability space, positioned skill-portability as a plugin-with-skills (not a CLI or framework)
- **README rewrite** — clear identity, differentiators vs competitors, superpowers acknowledgement, per-platform usage table with real invocation syntax
- **Install docs overhaul** — corrected marketplace name, GitHub URLs, `extraKnownMarketplaces` format, Cursor/Gemini/Copilot/Codex install paths, added per-platform skill invocation examples
- **Manifest fixes** — all GitHub URLs and marketplace name corrected across `.claude-plugin/` and `.cursor-plugin/`
- **Template consolidation** — moved templates into `lib/templates/`, added 3-mode rendering contract
- **Uplift skill improvements** — Phase 3 recommendation redesign, platform filtering, interactive recommendation, curated-note short-circuit
- **Self-uplift** — added Copilot CLI support, per-skill sidecars, session-start bootstrapping

## Test plan

- [ ] Verify `grep -rn "nathanielramm" README.md INSTALL.md .cursor-plugin/ .claude-plugin/` returns nothing
- [ ] Verify `grep -rn "skill-portability-dev" README.md INSTALL.md .claude-plugin/` returns nothing
- [ ] Verify INSTALL.md has "Using the skills" section for all 6 platforms
- [ ] Verify README.md usage table shows real invocation syntax (/, $, natural language)
- [ ] Run `assessing-plugin-portability` skill against this repo to confirm self-consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)