### PR TITLE
Release/v0.1.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "skill-portability-marketplace",
+  "interface": {
+    "displayName": "Skill Portability Marketplace"
+  },
+  "plugins": [
+    {
+      "name": "skill-portability",
+      "source": {
+        "source": "local",
+        "path": "."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "skill-portability",
+  "description": "Make any plugin fully portable across all platforms. Accepts Claude, Cursor, Gemini, OpenCode, or bare SKILL.md repos as input. Emits every missing platform artifact.",
+  "version": "0.1.0",
+  "skills": "./skills/",
+  "hooks": "./hooks/"
+}

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,0 +1,1 @@
+See [INSTALL.md](../INSTALL.md) for installation instructions.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -199,16 +199,45 @@ In Copilot CLI, invoke skills with the `/` prefix:
 
 ### Codex
 
-#### Skill-discovery install
+#### GitHub marketplace install
 
-Clone the repo and expose the skills directory:
+Register the repo as a Codex marketplace:
+
+```bash
+codex marketplace add hiivmind/skill-portability
+```
+
+This adds a marketplace entry to `~/.codex/config.toml`.
+
+Then open `/plugins` in Codex and install `skill-portability`.
+
+Codex persists the plugin enablement as a separate config entry:
+
+```toml
+[plugins."skill-portability@skill-portability-marketplace"]
+enabled = true
+```
+
+#### Local development install
+
+Use this only when you are intentionally testing a local checkout rather than installing from GitHub.
+
+```bash
+codex marketplace add /path/to/skill-portability
+```
+
+Then open `/plugins` in Codex and install `skill-portability`.
+
+#### Skill-discovery fallback
+
+If you only want the raw skills and do not need Codex plugin packaging, clone the repo and expose the skills directory:
 
 ```bash
 git clone https://github.com/hiivmind/skill-portability
 ln -s $(pwd)/skill-portability/skills ~/.agents/skills/skill-portability
 ```
 
-Restart Codex. Skills will be discoverable through native skill discovery.
+Use this as a fallback path, not the default install story for this repo.
 
 #### Context file
 
@@ -216,7 +245,11 @@ Codex uses `AGENTS.md` as its primary context file.
 
 #### Verify
 
-Start a new Codex session and check that skills are listed.
+Start a new Codex session and check one of:
+
+- `/plugins` shows `skill-portability` as installed
+- `~/.codex/config.toml` contains both the marketplace entry and the enabled plugin entry
+- `$assessing-plugin-portability` resolves in a fresh session
 
 #### Using the skills
 
@@ -300,10 +333,16 @@ ln -s /path/to/existing/skill-portability/skills skills/skill-portability
 
 ### Codex
 
-Symlink the skills directory from your existing checkout:
+For local development against an existing checkout, register the checkout itself as a marketplace:
+
+```bash
+codex marketplace add /path/to/existing/skill-portability
+```
+
+Then open `/plugins` in Codex and install `skill-portability`.
+
+If you only want skill discovery, symlink the skills directory from your existing checkout:
 
 ```bash
 ln -s /path/to/existing/skill-portability/skills ~/.agents/skills/skill-portability
 ```
-
-Restart Codex.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,157 @@
+# Publishing & Discoverability
+
+How to get **Skill Portability** discovered and installed on each platform.
+
+See [INSTALL.md](INSTALL.md) for end-user installation instructions.
+
+## Claude Code
+
+No public marketplace — distribution is via Git repositories.
+
+### Publishing
+
+Create a `.claude-plugin/marketplace.json` in your repo. No submission or review process — any Git repo with a valid marketplace manifest can be consumed.
+
+### How users find and install Skill Portability
+
+1. Register the marketplace: `/plugin marketplace add hiivmind/skill-portability`
+2. Install: `/plugin install skill-portability@skill-portability-marketplace`
+
+### Team distribution
+
+Teams can auto-register the marketplace by adding to their project `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "skill-portability-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "hiivmind/skill-portability"
+      }
+    }
+  }
+}
+```
+
+## Cursor
+
+Public marketplace at `cursor.com/marketplace` (curated, manually reviewed).
+
+### Publishing
+
+1. Ensure the plugin is open-source in a Git repository
+2. `.cursor-plugin/plugin.json` manifest must be present
+3. Submit at `cursor.com/marketplace/publish`
+4. Every plugin and update is manually reviewed
+
+### How users find and install Skill Portability
+
+- Browse the marketplace at `cursor.com/marketplace`
+- In Agent chat: `/add-plugin hiivmind/skill-portability`
+
+### Team distribution
+
+Cursor 2.6+ (Teams/Enterprise): admins import GitHub repos as team marketplaces via Dashboard Settings.
+
+## Gemini CLI
+
+Extensions gallery at [geminicli.com/extensions](https://geminicli.com/extensions/).
+
+### Publishing
+
+Publish as a GitHub repository with a `gemini-extension.json` manifest (requires `name`, `version`, `description`). Extensions are not vetted by Google.
+
+### How users find and install Skill Portability
+
+```bash
+gemini extensions install hiivmind/skill-portability
+```
+
+Users can browse the gallery or install directly from the GitHub URL.
+
+## OpenCode
+
+No marketplace. Distribution via npm or filesystem.
+
+### Publishing
+
+Publish the plugin as an npm package. No submission or review process.
+
+### How users find and install Skill Portability
+
+**npm:**
+Add to `opencode.json`:
+
+```json
+{
+  "plugin": ["skill-portability"]
+}
+```
+
+**Local files:**
+Copy `.opencode/plugins/skill-portability.js` to `.opencode/plugins/` (project) or `~/.config/opencode/plugins/` (global).
+
+Requires [Bun](https://bun.sh) for plugin loading.
+
+## Copilot CLI
+
+Skills published via GitHub CLI (v2.90.0+).
+
+### Publishing
+
+```bash
+gh skill publish [--fix]
+```
+
+Validates against the Agent Skills spec. No formal review — skills are published to the GitHub repository.
+
+### How users find and install Skill Portability
+
+```bash
+gh skill search skill-portability
+gh skill preview hiivmind/skill-portability skill-portability
+gh skill install hiivmind/skill-portability
+```
+
+### Third-party registries
+
+- [skills.sh](https://skills.sh) — community directory with 300k+ monthly views
+- [github/awesome-copilot](https://github.com/github/awesome-copilot) — GitHub's curated collection
+
+### Security note
+
+Always recommend users run `gh skill preview` before installing. GitHub does not vet third-party skills.
+
+## Codex
+
+Two publishing paths — choose based on what you're distributing.
+
+### Skill discovery (lightweight)
+
+For repos that are mostly instructions with no plugin UI metadata:
+
+- Submit a PR to `github.com/openai/skills` for inclusion in the curated catalog
+- Or publish as a standalone GitHub repo — users install via `$skill-installer install hiivmind/skill-portability`
+
+### Plugin packaging (full)
+
+For first-class plugin packages with marketplace metadata:
+
+- Create `.codex-plugin/plugin.json` and a `marketplace.json` listing the plugin
+- Users register via `codex plugin marketplace add hiivmind/skill-portability`
+- Public self-serve plugin publishing is coming soon per OpenAI docs
+
+### How users find and install Skill Portability
+
+**Skills path:**
+
+```bash
+$skill-installer install hiivmind/skill-portability
+```
+
+**Plugin path:**
+
+```bash
+codex plugin marketplace add hiivmind/skill-portability
+```

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -132,26 +132,32 @@ Two publishing paths — choose based on what you're distributing.
 For repos that are mostly instructions with no plugin UI metadata:
 
 - Submit a PR to `github.com/openai/skills` for inclusion in the curated catalog
-- Or publish as a standalone GitHub repo — users install via `$skill-installer install hiivmind/skill-portability`
+- Or publish as a standalone GitHub repo — users install through Codex skill discovery
+- Only recommend `$skill-installer install hiivmind/skill-portability` when the distributed artifact is truly a skill-only repo and does not depend on root-level plugin manifests, hooks, or shared context files
 
 ### Plugin packaging (full)
 
 For first-class plugin packages with marketplace metadata:
 
-- Create `.codex-plugin/plugin.json` and a `marketplace.json` listing the plugin
-- Users register via `codex plugin marketplace add hiivmind/skill-portability`
+- Create `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`
+- For a single-plugin GitHub repo, the marketplace entry should point at the repo root with `source.path: "."`
+- Users register via `codex marketplace add hiivmind/skill-portability`
+- Users then enable the plugin from `/plugins`
 - Public self-serve plugin publishing is coming soon per OpenAI docs
 
 ### How users find and install Skill Portability
 
-**Skills path:**
+**Skill-only repo:**
 
 ```bash
-$skill-installer install hiivmind/skill-portability
+git clone hiivmind/skill-portability
+ln -s $(pwd)/skill-portability/skills ~/.agents/skills/skill-portability
 ```
 
-**Plugin path:**
+**Plugin repo:**
 
 ```bash
-codex plugin marketplace add hiivmind/skill-portability
+codex marketplace add hiivmind/skill-portability
 ```
+
+Then enable `skill-portability` from `/plugins`.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Starting from whatever platform manifests already exist, it detects plugin metad
 | **Claude Code** | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `CLAUDE.md` |
 | **Cursor** | `.cursor-plugin/plugin.json` |
 | **Gemini CLI** | `gemini-extension.json`, `GEMINI.md` |
+| **Codex** | `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `.codex/INSTALL.md`, `AGENTS.md` |
 | **OpenCode** | `package.json`, `.opencode/plugins/<name>.js` |
-| **Generic harnesses** (Codex, Copilot CLI) | `AGENTS.md` |
+| **Copilot CLI** | `AGENTS.md` |
 | **Per-skill tool mapping** | `references/{copilot,codex,gemini}-tools.md` |
 | **Hook portability** | `hooks-cursor.json` derived from `hooks.json` |
 
@@ -93,9 +94,10 @@ gh skill install hiivmind/skill-portability
 **Codex:**
 
 ```bash
-git clone https://github.com/hiivmind/skill-portability
-ln -s $(pwd)/skill-portability/skills ~/.agents/skills/skill-portability
+codex marketplace add hiivmind/skill-portability
 ```
+
+Then open `/plugins` in Codex and install `skill-portability`.
 
 **OpenCode** — clone and copy the plugin entrypoint:
 

--- a/docs/platforms/codex.md
+++ b/docs/platforms/codex.md
@@ -23,18 +23,16 @@ Proper Codex plugin package.
 
 ```
 <root>/
+  .codex-plugin/
+    plugin.json
   .agents/
     plugins/
       marketplace.json
-  plugins/
-    my-plugin/
-      .codex-plugin/
-        plugin.json
-      skills/
-      hooks/
-      .mcp.json
-      .app.json
-      assets/
+  skills/
+  hooks/
+  .mcp.json
+  .app.json
+  assets/
 ```
 
 Key properties:
@@ -44,6 +42,10 @@ Key properties:
 - Discovery at plugin level, not only through raw skill discovery
 
 Use when: first-class Codex plugin package needed, bundles more than plain skill content, marketplace presentation desired.
+
+For a single-plugin GitHub repo, the marketplace entry should point back to the repo root with `source.path: "."`.
+
+Curated multi-plugin marketplace repos can still use `plugins/<name>/` packaging under one shared marketplace root.
 
 ### Upstream vs curated distinction
 
@@ -73,16 +75,25 @@ Location: `.agents/plugins/marketplace.json` (repo-local) or `~/.agents/plugins/
 
 ```json
 {
+  "name": "my-marketplace",
   "plugins": [
     {
       "name": "my-plugin",
-      "source": "./plugins/my-plugin",
-      "description": "...",
-      "version": "1.0.0"
+      "source": {
+        "source": "local",
+        "path": "."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }
 ```
+
+For a single-plugin upstream repo installed from GitHub, `path: "."` is the important detail: the marketplace entry points at the repository root because the repo itself is the plugin.
 
 ## Installation and discovery
 
@@ -98,17 +109,25 @@ Location: `.agents/plugins/marketplace.json` (repo-local) or `~/.agents/plugins/
 Two shapes:
 
 | Shape | Plugin path | Marketplace path |
-|-------|------------|-----------------|
-| Repo-local | `<repo>/plugins/<name>` | `<repo>/.agents/plugins/marketplace.json` |
+|-------|-------------|------------------|
+| Single-plugin upstream repo | `<repo>/` | `<repo>/.agents/plugins/marketplace.json` |
+| Curated multi-plugin repo | `<repo>/plugins/<name>` | `<repo>/.agents/plugins/marketplace.json` |
 | Home-local | `~/plugins/<name>` | `~/.agents/plugins/marketplace.json` |
 
 ### CLI marketplace commands
 
 ```bash
-codex plugin marketplace add owner/repo
-codex plugin marketplace add owner/repo --ref main
-codex plugin marketplace remove marketplace-name
-codex plugin marketplace upgrade [marketplace-name]
+codex marketplace add owner/repo
+codex marketplace add owner/repo --ref main
+codex marketplace add https://github.com/owner/repo
+codex marketplace add /path/to/local/marketplace-root
+```
+
+Current Codex CLI exposes marketplace registration directly. Plugin enablement then happens in the `/plugins` UI, or equivalently through `~/.codex/config.toml` by adding:
+
+```toml
+[plugins."my-plugin@my-marketplace"]
+enabled = true
 ```
 
 ### Built-in skill commands
@@ -149,7 +168,7 @@ Codex uses `AGENTS.md` as its primary context file.
 - `AGENTS.md` at project root or in `.agents/` directories
 - The `project_doc_fallback_filenames` config key can be expanded to recognize alternate names. `CLAUDE.md` is not a documented default fallback.
 
-For Codex skill-discovery installs, `.codex/INSTALL.md` should document the install path.
+For Codex plugin repos, `.codex/INSTALL.md` should point to the marketplace install instructions. For skill-discovery installs, it should document the symlink or copy path.
 
 ## Tool mapping
 
@@ -225,7 +244,7 @@ Codex supports hooks through its plugin system. Hook configuration follows a sim
 
 1. Two materially different consumption patterns — must decide skill-discovery vs plugin packaging
 2. No named agent registry — `spawn_agent` uses generic roles, not named types
-3. Multi-agent support requires explicit config flag
+3. Plugin installation is a two-step flow: marketplace registration, then plugin enablement
 4. Codex App sandbox may block branch/push operations (detached HEAD)
 5. Upstream source layout may differ from curated marketplace packaging
 6. `update_plan` instead of `TodoWrite` for task tracking
@@ -239,6 +258,7 @@ Score 3 when:
 - Explicit decision made between skill-discovery and plugin packaging
 - Chosen path fully implemented
 - `.codex-plugin/plugin.json` present if plugin path chosen
+- `.agents/plugins/marketplace.json` present if the repo should be installable as a Codex plugin from GitHub
 - Install docs match the chosen path
 
 Score 2 when:

--- a/docs/plugin-portability-patterns.md
+++ b/docs/plugin-portability-patterns.md
@@ -88,18 +88,16 @@ Minimal structure:
 
 ```text
 <root>/
+  .codex-plugin/
+    plugin.json
   .agents/
     plugins/
       marketplace.json
-  plugins/
-    my-plugin/
-      .codex-plugin/
-        plugin.json
-      skills/
-      hooks/
-      .mcp.json
-      .app.json
-      assets/
+  skills/
+  hooks/
+  .mcp.json
+  .app.json
+  assets/
 ```
 
 Key properties:
@@ -115,6 +113,9 @@ Use this pattern when:
 - you want one installable unit for multiple capabilities
 - you need Codex plugin metadata or marketplace presentation
 - you want the repo to model plugin packaging explicitly, not only skill loading
+
+For a single-plugin GitHub repo, `.agents/plugins/marketplace.json` should point to the repo root with `source.path: "."`.
+Use the `plugins/<name>/` layout only for curated marketplace repos that contain multiple plugins.
 
 ### Important portability note
 
@@ -380,7 +381,8 @@ Choose this when:
 Typical output:
 
 - `.codex-plugin/plugin.json`
-- repo-local or home-local `marketplace.json`
+- `.agents/plugins/marketplace.json` with `source.path: "."` for single-plugin repos
+- repo-local or home-local `marketplace.json` using `plugins/<name>/` for curated multi-plugin repos
 - optional bundled `skills`, `hooks`, `.mcp.json`, `.app.json`
 - install guidance for plugin registration and discovery
 
@@ -426,7 +428,11 @@ Use this when the uplifted repo ships `.codex-plugin/plugin.json`.
 
 Two common shapes:
 
-- **repo-local marketplace**
+- **single-plugin upstream repo**
+  - plugin at `<repo>/`
+  - marketplace at `<repo>/.agents/plugins/marketplace.json`
+  - marketplace entry points at `.`
+- **curated multi-plugin repo**
   - plugin at `<repo>/plugins/<plugin-name>`
   - marketplace at `<repo>/.agents/plugins/marketplace.json`
 - **home-local marketplace**
@@ -437,8 +443,10 @@ Users need:
 
 1. the plugin directory in the expected location
 2. a valid `.codex-plugin/plugin.json`
-3. a marketplace entry pointing at `./plugins/<plugin-name>`
-4. a Codex restart or refresh
+3. a marketplace entry pointing at `.` for single-plugin repos, or `./plugins/<plugin-name>` for curated multi-plugin repos
+4. `codex marketplace add <owner/repo>` or `codex marketplace add <local-path>`
+5. plugin enablement in `/plugins` or an equivalent `[plugins."<plugin>@<marketplace>"]` entry in `~/.codex/config.toml`
+6. a Codex restart or fresh session if the plugin is not immediately visible
 
 This is the proper Codex plugin installation pattern.
 

--- a/examples/assessment-hiivmind-corpus.md
+++ b/examples/assessment-hiivmind-corpus.md
@@ -1,0 +1,157 @@
+# Example: Assessing hiivmind-corpus
+
+This is sample output from running the `assessing-plugin-portability` skill against
+[hiivmind-corpus](https://github.com/hiivmind/hiivmind-corpus), a Claude Code plugin
+for documentation corpus management.
+
+The plugin was Claude-first with no cross-platform artifacts. The assessment identified
+it as a candidate for full portable plugin uplift.
+
+---
+
+## Platform Scores
+
+```text
+┌─────────────┬───────┬─────────┬───────────────────────────────────────┐
+│ Platform    │ Score │ Band    │ Action                                │
+├─────────────┼───────┼─────────┼───────────────────────────────────────┤
+│ claude-code │ 18/21 │ Strong  │ No action required (Native)           │
+│ cursor      │ 6/21  │ Partial │ Significant gaps — uplift recommended │
+│ gemini-cli  │ 6/21  │ Partial │ Significant gaps — uplift recommended │
+│ opencode    │ 3/21  │ Weak    │ Full uplift required                  │
+│ copilot-cli │ 6/21  │ Partial │ Significant gaps — uplift recommended │
+│ codex       │ 6/21  │ Partial │ Significant gaps — uplift recommended │
+└─────────────┴───────┴─────────┴───────────────────────────────────────┘
+```
+
+Scores use a 7-category rubric (max 3 points each, 21 total). See
+[rubric-framework.md](../lib/patterns/rubric-framework.md) for category definitions.
+
+---
+
+## Per-Platform Detail
+
+### claude-code — 18/21 (Strong)
+
+```text
+┌─────────────────────┬───────┐
+│ Category            │ Score │
+├─────────────────────┼───────┤
+│ Manifest packaging  │ 3/3   │
+│ Skill compatibility │ 3/3   │
+│ Context delivery    │ 3/3   │
+│ Hook portability    │ 1/3   │
+│ Tool mapping        │ 3/3   │
+│ Install readiness   │ 3/3   │
+│ Runtime adapters    │ 2/3   │
+│ Total               │ 18/21 │
+└─────────────────────┴───────┘
+```
+
+The plugin scores Strong on its native platform. Hook portability (1/3) and runtime
+adapters (2/3) are the only gaps — hooks exist but are Claude-specific, and some
+runtime features lack cross-platform equivalents.
+
+### cursor — 6/21 (Partial)
+
+```text
+┌─────────────────────┬───────┐
+│ Category            │ Score │
+├─────────────────────┼───────┤
+│ Manifest packaging  │ 0/3   │
+│ Skill compatibility │ 3/3   │
+│ Context delivery    │ 0/3   │
+│ Hook portability    │ 0/3   │
+│ Tool mapping        │ 3/3   │
+│ Install readiness   │ 0/3   │
+│ Runtime adapters    │ 0/3   │
+│ Total               │ 6/21  │
+└─────────────────────┴───────┘
+```
+
+Skills are compatible (SKILL.md frontmatter is valid) and tool mapping scores full
+marks because Cursor shares Claude Code's tool names. Everything else is missing:
+no `.cursor-plugin/plugin.json`, no `AGENTS.md`, no Cursor-format hooks.
+
+### gemini-cli — 6/21 (Partial)
+
+```text
+┌─────────────────────┬───────┐
+│ Category            │ Score │
+├─────────────────────┼───────┤
+│ Manifest packaging  │ 0/3   │
+│ Skill compatibility │ 3/3   │
+│ Context delivery    │ 0/3   │
+│ Hook portability    │ 0/3   │
+│ Tool mapping        │ 0/3   │
+│ Install readiness   │ 0/3   │
+│ Runtime adapters    │ 0/3   │
+│ Total               │ 6/21  │
+└─────────────────────┴───────┘
+```
+
+Skills are compatible but tool mapping scores 0 — Gemini CLI uses different tool
+names and no `gemini-tools.md` sidecars exist. No `gemini-extension.json` manifest
+or `GEMINI.md` context file.
+
+---
+
+## Blockers
+
+- **Major:** Unresolved tool assumptions in all skills (no tool-mapping sidecars found).
+- **Minor:** `GEMINI.md` and `AGENTS.md` missing — cannot check includes.
+- **Minor:** Installation instructions in `README.md` are Claude-specific.
+
+---
+
+## Uplift Recommendation
+
+| Field | Value |
+| ----- | ----- |
+| Target | `full-portable-plugin` |
+| Codex path | `native-plugin-packaging` |
+
+---
+
+## Required Artifacts
+
+### cursor — Partial
+
+- `.cursor-plugin/plugin.json`
+- `AGENTS.md`
+- `hooks/hooks-cursor.json`
+
+### gemini-cli — Partial
+
+- `gemini-extension.json`
+- `GEMINI.md`
+- `skills/*/references/gemini-tools.md`
+
+### opencode — Weak
+
+- `package.json`
+- `.opencode/plugins/hiivmind-corpus.js`
+
+### copilot-cli — Partial
+
+- `.github/copilot-instructions.md`
+- `skills/*/references/copilot-tools.md`
+
+### codex — Partial
+
+- `.codex-plugin/plugin.json`
+- `skills/*/references/codex-tools.md`
+
+---
+
+## Session-Start Injection
+
+`NOT CONFIGURED`
+
+---
+
+## Summary
+
+Run the `uplifting-a-plugin` skill to generate all missing artifacts automatically.
+This will transform hiivmind-corpus from a Claude-first plugin into a fully portable
+multi-platform plugin with native manifests, tool mappings, and unified documentation.

--- a/lib/patterns/manifest-generation.md
+++ b/lib/patterns/manifest-generation.md
@@ -73,6 +73,7 @@ RENDER_WITH_BUILDER(template, metadata, computed):
 | opencode-package | Plain | `lib/templates/manifests/package.json.tmpl` |
 | opencode-shim | Plain | `lib/templates/manifests/opencode-plugin.js.tmpl` |
 | codex-plugin | Plain | `lib/templates/manifests/codex-plugin/plugin.json.tmpl` |
+| codex-marketplace | Plain | `lib/templates/manifests/codex-plugin/marketplace.json.tmpl` |
 | copilot-instructions | Plain | `lib/templates/context-files/copilot-instructions.md.tmpl` |
 
 ---
@@ -168,6 +169,18 @@ Create `.opencode/plugins/` directory if needed. This is the minimal non-bootstr
 Create `.codex-plugin/` directory if needed. Only generated when Codex recommendation is `native-plugin-packaging`.
 
 > **Template:** `lib/templates/manifests/codex-plugin/plugin.json.tmpl`
+
+---
+
+## codex-marketplace
+
+**Target:** `.agents/plugins/marketplace.json`
+
+Create `.agents/plugins/` directory if needed. Only generated when Codex recommendation is `native-plugin-packaging`.
+
+For single-plugin upstream repos, this manifest points to the repo root with `source.path: "."`.
+
+> **Template:** `lib/templates/manifests/codex-plugin/marketplace.json.tmpl`
 
 ---
 

--- a/lib/templates/install-docs/adding-platform/codex.md
+++ b/lib/templates/install-docs/adding-platform/codex.md
@@ -1,9 +1,15 @@
 ### Codex
 
-Symlink the skills directory from your existing checkout:
+For local development against an existing checkout, register the checkout itself as a marketplace:
+
+```bash
+codex marketplace add /path/to/existing/{{name}}
+```
+
+Then open `/plugins` in Codex and install `{{name}}`.
+
+If you only want skill discovery, symlink the skills directory from your existing checkout:
 
 ```bash
 ln -s /path/to/existing/{{name}}/skills ~/.agents/skills/{{name}}
 ```
-
-Restart Codex.

--- a/lib/templates/install-docs/codex.md
+++ b/lib/templates/install-docs/codex.md
@@ -1,36 +1,44 @@
 ## Codex
 
-### Skill-discovery install
+Codex supports two different install shapes. Use the one that matches what this repo ships.
 
-Clone the repo and expose the skills directory:
+### Native plugin packaging
+
+If the repo includes both `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`, install it as a Codex plugin:
+
+```bash
+codex marketplace add {{repository}}
+```
+
+Then open `/plugins` in Codex and install `{{name}}`.
+
+Codex persists the plugin enablement as a separate config entry:
+
+```toml
+[plugins."{{name}}@{{marketplaceName}}"]
+enabled = true
+```
+
+### Local development for plugin repos
+
+Use this only when you are intentionally testing a local checkout rather than installing from GitHub:
+
+```bash
+codex marketplace add /path/to/{{name}}
+```
+
+Then open `/plugins` in Codex and install `{{name}}`.
+
+### Skill discovery
+
+If the repo is published as raw skills only, or you only want the skills and do not need Codex plugin packaging, clone the repo and expose the skills directory:
 
 ```bash
 git clone {{repository}}
 ln -s $(pwd)/{{name}}/skills ~/.agents/skills/{{name}}
 ```
 
-Restart Codex. Skills will be discoverable through native skill discovery.
-
-### Native plugin install
-
-If packaged as a Codex plugin:
-
-1. Ensure `.codex-plugin/plugin.json` exists in the plugin directory
-2. Add a marketplace entry:
-
-```json
-{
-  "plugins": [
-    {
-      "name": "{{name}}",
-      "source": "./plugins/{{name}}"
-    }
-  ]
-}
-```
-
-1. Place `marketplace.json` at `~/.agents/plugins/marketplace.json` (home-local) or `<repo>/.agents/plugins/marketplace.json` (repo-local)
-2. Restart Codex
+Use this path when the repo does not ship Codex plugin manifests, or when you intentionally want skills without plugin packaging.
 
 ### Context file
 
@@ -38,7 +46,7 @@ Codex uses `AGENTS.md` as its primary context file.
 
 ### Multi-agent support
 
-If this plugin's skills use subagent dispatch, enable multi-agent mode:
+If this plugin's skills use subagent dispatch, confirm multi-agent mode is enabled:
 
 ```toml
 # ~/.codex/config.toml
@@ -48,4 +56,8 @@ multi_agent = true
 
 ### Verify
 
-Start a new Codex session and check that skills are listed.
+Start a new Codex session and check one of:
+
+- `/plugins` shows `{{name}}` as installed
+- `~/.codex/config.toml` contains both the marketplace entry and the enabled plugin entry
+- the relevant `$` skill resolves in a fresh session

--- a/lib/templates/install-docs/publishing/codex.md
+++ b/lib/templates/install-docs/publishing/codex.md
@@ -7,26 +7,32 @@ Two publishing paths — choose based on what you're distributing.
 For repos that are mostly instructions with no plugin UI metadata:
 
 - Submit a PR to `github.com/openai/skills` for inclusion in the curated catalog
-- Or publish as a standalone GitHub repo — users install via `$skill-installer install {{repository}}`
+- Or publish as a standalone GitHub repo — users install through Codex skill discovery
+- Only recommend `$skill-installer install {{repository}}` when the distributed artifact is truly a skill-only repo and does not depend on root-level plugin manifests, hooks, or shared context files
 
 ### Plugin packaging (full)
 
 For first-class plugin packages with marketplace metadata:
 
-- Create `.codex-plugin/plugin.json` and a `marketplace.json` listing the plugin
-- Users register via `codex plugin marketplace add {{repository}}`
+- Create `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`
+- For a single-plugin GitHub repo, the marketplace entry should point at the repo root with `source.path: "."`
+- Users register via `codex marketplace add {{repository}}`
+- Users then enable the plugin from `/plugins`
 - Public self-serve plugin publishing is coming soon per OpenAI docs
 
 ### How users find and install {{displayName}}
 
-**Skills path:**
+**Skill-only repo:**
 
 ```bash
-$skill-installer install {{repository}}
+git clone {{repository}}
+ln -s $(pwd)/{{name}}/skills ~/.agents/skills/{{name}}
 ```
 
-**Plugin path:**
+**Plugin repo:**
 
 ```bash
-codex plugin marketplace add {{repository}}
+codex marketplace add {{repository}}
 ```
+
+Then enable `{{name}}` from `/plugins`.

--- a/lib/templates/manifests/codex-plugin/marketplace.json.tmpl
+++ b/lib/templates/manifests/codex-plugin/marketplace.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "name": "{{marketplaceName}}",
+  "interface": {
+    "displayName": "{{displayName}} Marketplace"
+  },
+  "plugins": [
+    {
+      "name": "{{name}}",
+      "source": {
+        "source": "local",
+        "path": "."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/skills/assessing-plugin-portability/SKILL.md
+++ b/skills/assessing-plugin-portability/SKILL.md
@@ -58,7 +58,7 @@ DETECT(plugin_path):
 
 ### Step 2.1: Check Platform Manifests
 
-Check all 9 manifest paths across 5 platforms, recording `{ platform, path, status }`:
+Check all 10 manifest paths across 6 platforms, recording `{ platform, path, status }`:
 
 ```pseudocode
 INVENTORY_MANIFESTS(computed):
@@ -70,6 +70,7 @@ INVENTORY_MANIFESTS(computed):
     { platform: "gemini-cli",   path: "GEMINI.md" },
     { platform: "opencode",     path: ".opencode/plugins/" + computed.metadata.name + ".js" },
     { platform: "codex",        path: ".codex-plugin/plugin.json" },
+    { platform: "codex",        path: ".agents/plugins/marketplace.json" },
     { platform: "copilot-cli",  path: "package.json" },
     { platform: "copilot-cli",  path: ".github/copilot-instructions.md" }
   ]

--- a/skills/uplifting-a-plugin/SKILL.md
+++ b/skills/uplifting-a-plugin/SKILL.md
@@ -99,6 +99,7 @@ CHECK_CONFLICTS(computed):
     { path: ".claude-plugin/marketplace.json",                     platform: "claude-code" },
     { path: ".cursor-plugin/plugin.json",                          platform: "cursor"      },
     { path: ".codex-plugin/plugin.json",                           platform: "codex"       },
+    { path: ".agents/plugins/marketplace.json",                    platform: "codex"       },
     { path: "gemini-extension.json",                               platform: "gemini-cli"  },
     { path: "GEMINI.md",                                           platform: "gemini-cli"  },
     { path: "AGENTS.md",                                           platform: "cross"       },
@@ -268,6 +269,8 @@ GENERATE_MANIFESTS(computed):
     { target: ".opencode/plugins/{{name}}.js",   platform: "opencode",    schema: "opencode-shim"         },
     { target: ".codex-plugin/plugin.json",       platform: "codex",       schema: "codex-plugin",
       condition: "computed.codex_rec == 'native-plugin-packaging'"                                        },
+    { target: ".agents/plugins/marketplace.json", platform: "codex",      schema: "codex-marketplace",
+      condition: "computed.codex_rec == 'native-plugin-packaging'"                                        },
     { target: "AGENTS.md",                       platform: "cross",       schema: "agents-context"        },
     { target: ".github/copilot-instructions.md", platform: "copilot-cli", schema: "copilot-instructions"  },
   ]
@@ -308,7 +311,8 @@ The `is_manifest()` predicate classifies schemas as packaging vs context:
 ```pseudocode
 MANIFEST_SCHEMAS = [
   "claude-plugin", "claude-marketplace", "cursor-plugin",
-  "gemini-extension", "opencode-package", "opencode-shim", "codex-plugin"
+  "gemini-extension", "opencode-package", "opencode-shim", "codex-plugin",
+  "codex-marketplace"
 ]
 CONTEXT_SCHEMAS = [
   "claude-context", "gemini-context", "agents-context", "copilot-instructions"


### PR DESCRIPTION
Title:
  [codex] Add Codex plugin packaging and install guidance

  Body:

  ## Summary

  Updates the repo's Codex portability story from skill-symlink-only guidance to a complete native plugin packaging path.

  This PR:
  - adds native Codex plugin artifacts for this repo
  - documents the real Codex install flow using `codex marketplace add ...` and `/plugins`
  - adds a Codex marketplace manifest template for uplifted plugins
  - updates uplift and assessment guidance so `.agents/plugins/marketplace.json` is treated as part of native Codex packaging
  - refreshes Codex install and publishing templates to match the current CLI behavior

  ## Why

  The repo is supposed to generate portable plugin artifacts, so it needs to model and document Codex plugin installation correctly.

  During local verification we found that:
  - non-curated Codex marketplaces can coexist with curated plugins
  - the current CLI surface is `codex marketplace add ...`
  - enabling a plugin is a separate step after marketplace registration
  - native Codex packaging for a single-plugin GitHub repo needs both `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`

  ## Impact

  Plugin authors using Skill Portability should now get a Codex-native output that is closer to actually installable from GitHub, and the generated docs no longer point at outdated Codex commands.

  ## Validation

  Validated by local inspection and manual repo-level verification:
  - confirmed the Codex CLI surface locally
  - confirmed custom marketplaces coexist with curated plugins
  - verified the updated repo docs and generated Codex docs/templates are internally consistent

  No automated end-to-end uplift smoke test was run in this pass.

  Base branch: main
  Compare branch: release/v0.1.0
