### PR TITLE
Fix Codex marketplace local path

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -8,7 +8,7 @@
       "name": "skill-portability",
       "source": {
         "source": "local",
-        "path": "."
+        "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -140,7 +140,7 @@ For repos that are mostly instructions with no plugin UI metadata:
 For first-class plugin packages with marketplace metadata:
 
 - Create `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`
-- For a single-plugin GitHub repo, the marketplace entry should point at the repo root with `source.path: "."`
+- For a single-plugin GitHub repo, the marketplace entry should point at the repo root with `source.path: "./"`
 - Users register via `codex marketplace add hiivmind/skill-portability`
 - Users then enable the plugin from `/plugins`
 - Public self-serve plugin publishing is coming soon per OpenAI docs

--- a/docs/platforms/codex.md
+++ b/docs/platforms/codex.md
@@ -43,7 +43,7 @@ Key properties:
 
 Use when: first-class Codex plugin package needed, bundles more than plain skill content, marketplace presentation desired.
 
-For a single-plugin GitHub repo, the marketplace entry should point back to the repo root with `source.path: "."`.
+For a single-plugin GitHub repo, the marketplace entry should point back to the repo root with `source.path: "./"`.
 
 Curated multi-plugin marketplace repos can still use `plugins/<name>/` packaging under one shared marketplace root.
 
@@ -81,7 +81,7 @@ Location: `.agents/plugins/marketplace.json` (repo-local) or `~/.agents/plugins/
       "name": "my-plugin",
       "source": {
         "source": "local",
-        "path": "."
+        "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",
@@ -93,7 +93,7 @@ Location: `.agents/plugins/marketplace.json` (repo-local) or `~/.agents/plugins/
 }
 ```
 
-For a single-plugin upstream repo installed from GitHub, `path: "."` is the important detail: the marketplace entry points at the repository root because the repo itself is the plugin.
+For a single-plugin upstream repo installed from GitHub, `path: "./"` is the important detail: the marketplace entry points at the repository root because the repo itself is the plugin.
 
 ## Installation and discovery
 

--- a/docs/plugin-portability-patterns.md
+++ b/docs/plugin-portability-patterns.md
@@ -114,7 +114,7 @@ Use this pattern when:
 - you need Codex plugin metadata or marketplace presentation
 - you want the repo to model plugin packaging explicitly, not only skill loading
 
-For a single-plugin GitHub repo, `.agents/plugins/marketplace.json` should point to the repo root with `source.path: "."`.
+For a single-plugin GitHub repo, `.agents/plugins/marketplace.json` should point to the repo root with `source.path: "./"`.
 Use the `plugins/<name>/` layout only for curated marketplace repos that contain multiple plugins.
 
 ### Important portability note
@@ -381,7 +381,7 @@ Choose this when:
 Typical output:
 
 - `.codex-plugin/plugin.json`
-- `.agents/plugins/marketplace.json` with `source.path: "."` for single-plugin repos
+- `.agents/plugins/marketplace.json` with `source.path: "./"` for single-plugin repos
 - repo-local or home-local `marketplace.json` using `plugins/<name>/` for curated multi-plugin repos
 - optional bundled `skills`, `hooks`, `.mcp.json`, `.app.json`
 - install guidance for plugin registration and discovery

--- a/lib/patterns/manifest-generation.md
+++ b/lib/patterns/manifest-generation.md
@@ -178,7 +178,7 @@ Create `.codex-plugin/` directory if needed. Only generated when Codex recommend
 
 Create `.agents/plugins/` directory if needed. Only generated when Codex recommendation is `native-plugin-packaging`.
 
-For single-plugin upstream repos, this manifest points to the repo root with `source.path: "."`.
+For single-plugin upstream repos, this manifest points to the repo root with `source.path: "./"`.
 
 > **Template:** `lib/templates/manifests/codex-plugin/marketplace.json.tmpl`
 

--- a/lib/templates/install-docs/publishing/codex.md
+++ b/lib/templates/install-docs/publishing/codex.md
@@ -15,7 +15,7 @@ For repos that are mostly instructions with no plugin UI metadata:
 For first-class plugin packages with marketplace metadata:
 
 - Create `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`
-- For a single-plugin GitHub repo, the marketplace entry should point at the repo root with `source.path: "."`
+- For a single-plugin GitHub repo, the marketplace entry should point at the repo root with `source.path: "./"`
 - Users register via `codex marketplace add {{repository}}`
 - Users then enable the plugin from `/plugins`
 - Public self-serve plugin publishing is coming soon per OpenAI docs

--- a/lib/templates/manifests/codex-plugin/marketplace.json.tmpl
+++ b/lib/templates/manifests/codex-plugin/marketplace.json.tmpl
@@ -8,7 +8,7 @@
       "name": "{{name}}",
       "source": {
         "source": "local",
-        "path": "."
+        "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",


### PR DESCRIPTION
  Title

  Fix Codex marketplace local path validation

  Body

  ## Summary

  This fixes Codex marketplace installation for `hiivmind/skill-portability`.

  Codex currently rejects the repo’s marketplace manifest because local plugin source paths must start with `./`. Our shipped Codex marketplace artifact and the Codex manifest template were using `"path": "."`, which causes `codex
  marketplace add hiivmind/skill-portability` to fail during validation.

  This change updates the live manifest, the Codex marketplace template, and the related Codex documentation so the repo and future generated artifacts consistently use `"path": "./"`.

  ## Changes

  - update `.agents/plugins/marketplace.json` to use `"path": "./"`
  - update `lib/templates/manifests/codex-plugin/marketplace.json.tmpl` to emit `"path": "./"`
  - update Codex publishing and portability docs to match the current validator behavior

  ## Root cause

  The repo encoded an outdated assumption about Codex local marketplace paths. The current Codex validator accepts local paths only when they begin with `./`, so `"."` is no longer valid.

  ## Validation

  - reproduced the failure from `codex marketplace add hiivmind/skill-portability`
  - verified the committed manifest now uses `"path": "./"`
  - confirmed the updated manifest parses successfully with `node`
  - checked the relevant Codex docs/templates for stale `source.path: "."` guidance
